### PR TITLE
Fix duplicate team names in all-team records

### DIFF
--- a/pages/team/allteamsrecords.js
+++ b/pages/team/allteamsrecords.js
@@ -5,6 +5,9 @@ import NavBar from '../../components/NavBar';
 import AdUnit from '../../components/AdUnit';
 import { fetchFromApi } from '../../utils/ssr';
 
+const cleanTeamName = (name = '') =>
+  name.replace(/^#\d+\s*/, '').split('(')[0].trim();
+
 export default function AllTeamsRecords({ data }) {
   const [filter, setFilter] = useState('');
   const [sortKey, setSortKey] = useState('wins');
@@ -14,12 +17,12 @@ export default function AllTeamsRecords({ data }) {
 
   const teamSet = new Set();
   data.forEach((reign) => {
-    teamSet.add(reign.beltHolder);
+    teamSet.add(cleanTeamName(reign.beltHolder));
     (reign.defenses || []).forEach((defText) => {
       const match = defText.match(/^(vs\.|at) (.*?) \((W|L|T) (\d+)[\-\u2013](\d+)\)/);
       if (match) {
         const opponentRaw = match[2];
-        teamSet.add(opponentRaw.trim());
+        teamSet.add(cleanTeamName(opponentRaw));
       }
     });
   });


### PR DESCRIPTION
## Summary
- strip rankings and parentheses from team names when building All Teams Records list

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b852cec1788332ba5eabdc637c504d