### PR TITLE
Update South Florida matchup and parsing

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -28,7 +28,7 @@ export default function HomePage({ data }) {
   const router = useRouter();
   const page = parseInt(router.query.page || '1', 10);
   const itemsPerPage = 10;
-  const nextOpponent = 'Long Island University';
+  const nextOpponent = 'South Florida';
 
   if (!data.length) return <p></p>;
 
@@ -169,7 +169,7 @@ export default function HomePage({ data }) {
         </tbody>
       </table>
 <div style={{ marginBottom: '1rem',  color: '#000' }}>
-  Florida starts its 2025 season belt defense taking on the Long Island Sharks, an opponent requested by long departed coach Jim McElwain. The Sharks have unsurprisingly never played in a belt game before. With an expected win Florida will move up to a 14th place tie in total wins with Auburn.
+  Florida continues its 2025 belt defense with an in-state clash against the South Florida Bulls. The Bulls have taken their shots at the belt before but have yet to capture it. A win would keep the Gators' reign alive and push them toward a 14th-place tie in total wins with Auburn.
 </div>
   
 

--- a/pages/team/allteamsrecords.js
+++ b/pages/team/allteamsrecords.js
@@ -19,7 +19,7 @@ export default function AllTeamsRecords({ data }) {
   data.forEach((reign) => {
     teamSet.add(cleanTeamName(reign.beltHolder));
     (reign.defenses || []).forEach((defText) => {
-      const match = defText.match(/^(vs\.|at) (.*?) \((W|L|T) (\d+)[\-\u2013](\d+)\)/);
+      const match = defText.match(/^(vs\.?|at) (?:#\d+ )?(.*?) \((W|L|T) (\d+)[\-\u2013](\d+)\)/);
       if (match) {
         const opponentRaw = match[2];
         teamSet.add(cleanTeamName(opponentRaw));

--- a/utils/teamUtils.js
+++ b/utils/teamUtils.js
@@ -37,6 +37,7 @@ export const teamLogoMap = {
   Pittsburgh: 221,
   Purdue: 2509,
   SouthCarolina: 2579,
+  SouthFlorida: 58,
   Stanford: 24,
   Syracuse: 183,
   Tennessee: 2633,


### PR DESCRIPTION
## Summary
- Set South Florida as upcoming opponent on home page with preview description
- Add South Florida logo ID to team logo map
- Loosen All Teams Records opponent regex to handle ranked listings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b855c054b88332bb805df94605be15