### PR TITLE
Update homepage text for South Florida belt clash

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -169,7 +169,7 @@ export default function HomePage({ data }) {
         </tbody>
       </table>
 <div style={{ marginBottom: '1rem',  color: '#000' }}>
-  Florida continues its 2025 belt defense with an in-state clash against the South Florida Bulls. The Bulls have taken their shots at the belt before but have yet to capture it. A win would keep the Gators' reign alive and push them toward a 14th-place tie in total wins with Auburn.
+  Florida continues its 2025 belt defense with an in-state clash against the South Florida Bulls. This is the Bulls first ever College Football Belt game. A win would keep the Gators' reign alive and push them toward a 14th-place tie in total wins with Auburn.
 </div>
   
 


### PR DESCRIPTION
## Summary
- revise index page paragraph to note South Florida's first-ever belt game and implications for Florida's win total

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive configuration)
- `npm run build` (fails: missing `next-sitemap.config.js`)
- `curl -s http://localhost:3000 | grep -o "Florida continues its 2025 belt defense"`


------
https://chatgpt.com/codex/tasks/task_e_68b86bcdd1a88332b342a932b0331cda