### PR TITLE
feat: set Miami as next opponent

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -28,7 +28,7 @@ export default function HomePage({ data }) {
   const router = useRouter();
   const page = parseInt(router.query.page || '1', 10);
   const itemsPerPage = 10;
-  const nextOpponent = 'South Florida';
+  const nextOpponent = 'Miami';
 
   if (!data.length) {
     return (
@@ -185,7 +185,7 @@ export default function HomePage({ data }) {
         </tbody>
       </table>
 <div style={{ marginBottom: '1rem',  color: '#000' }}>
-  Florida continues its 2025 belt defense with an in-state clash against the South Florida Bulls. This is the Bulls first ever College Football Belt game. A win would keep the Gators' reign alive and push them toward a 14th-place tie in total wins with Auburn.
+  Florida continues its 2025 belt defense with an in-state clash against the Miami Hurricanes. This is the Hurricanes' first ever College Football Belt game. A win would keep the Gators' reign alive and push them toward a 14th-place tie in total wins with Auburn.
 </div>
   
 


### PR DESCRIPTION
## Summary
- update upcoming opponent to Miami in homepage
- mention Miami Hurricanes in teaser for next game

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68beda20037083328ed14c9ac65b3b58