### PR TITLE
Track South Florida belt win over Florida

### DIFF
--- a/data/belt-history.csv
+++ b/data/belt-history.csv
@@ -1,5 +1,6 @@
 Overall Reign #,BeltHolder,TeamReign,StartofReign,EndofReign,# of Defenses,BeltWon,Defense 1,Defense 2,Defense 3,Defense 4,Defense 5,Defense 6,Defense 7,Defense 8,Defense 9,Defense 10,Defense 11,Defense 12,Defense 13,Defense 14,Defense 15,Defense 16,Defense 17,Defense 18,Defense 19,Defense 20,Defense 21,Defense 22,Defense 23,Defense 24,Defense 25,Defense 26,Defense 27,Defense 28,Defense 29,Defense 30,Defense 31,Defense 32,Defense 33,Defense 34,Defense 35,Defense 36,Defense 37
-330,Florida,6,11/23/2024,Ongoing,2,vs. #9 Ole Miss (W 24–14),at Florida State (W 31–11),vs. Tulane (Gasparilla Bowl) (W 33–8),vs. LIU (W 55-0),vs. South Florida,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+331,South Florida,1,09/06/2025,Ongoing,0,at Florida (W 18–16),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+330,Florida,6,11/23/2024,09/06/2025,3,vs. #9 Ole Miss (W 24–14),at Florida State (W 31–11),vs. Tulane (Gasparilla Bowl) (W 33–8),vs. LIU (W 55-0),vs. South Florida (L 18-16),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 329,Ole Miss,6,11/10/2024,11/23/2024,0,vs. Georgia (W 28–10),at Florida (L 24–14),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 328,Georgia,6,10/19/2024,11/10/2024,1,at Texas (W 30–15),vs. Florida (neutral site) (W 34–20),at Ole Miss (L 28–10),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 327,Texas,6,09/07/2024,10/19/2024,4,at Michigan (W 31–12),vs. UTSA (W 56–7),vs. ULM (W 51–3),vs. Mississippi State (W 35–13),vs. Oklahoma (W 34–3),vs. Georgia (L 30–15),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,

--- a/pages/index.js
+++ b/pages/index.js
@@ -28,7 +28,7 @@ export default function HomePage({ data }) {
   const router = useRouter();
   const page = parseInt(router.query.page || '1', 10);
   const itemsPerPage = 10;
-  const nextOpponent = 'South Florida';
+  const nextOpponent = 'Alabama';
 
   if (!data.length) {
     return (
@@ -185,7 +185,7 @@ export default function HomePage({ data }) {
         </tbody>
       </table>
 <div style={{ marginBottom: '1rem',  color: '#000' }}>
-  Florida continues its 2025 belt defense with an in-state clash against the South Florida Bulls. This is the Bulls first ever College Football Belt game. A win would keep the Gators' reign alive and push them toward a 14th-place tie in total wins with Auburn.
+  South Florida begins its 2025 belt reign with a showdown against the Alabama Crimson Tide. The Bulls seek their first defense and aim to extend their stay atop the College Football Belt.
 </div>
   
 


### PR DESCRIPTION
## Summary
- Record South Florida's 18-16 upset of Florida in belt history
- End Florida's reign and note upcoming Alabama matchup on the homepage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bebc9ab0dc8332ae2dfd03e1ac56a5