### PR TITLE
Add alt text and meta tags for improved accessibility and SEO

### DIFF
--- a/pages/blog.js
+++ b/pages/blog.js
@@ -8,6 +8,7 @@ export default function Blog() {
       <Head>
         <title>CFB Belt Blog</title>
         <meta name="description" content="Follow the latest updates and insights about the College Football Belt." />
+        <meta property="og:image" content="/images/2025week1.png" />
       </Head>
 
       <NavBar />

--- a/pages/index.js
+++ b/pages/index.js
@@ -212,7 +212,13 @@ export default function HomePage({ data }) {
               <tr key={idx} style={{ backgroundColor: idx % 2 === 0 ? '#f5f7fa' : 'white' }}>
                 <td style={styles.tableCell}>
                   <div style={{ display: 'flex', alignItems: 'center' }}>
-                    {logoUrl && <img src={logoUrl} alt="" style={{ height: 24, marginRight: 8 }} />}
+                    {logoUrl && (
+                      <img
+                        src={logoUrl}
+                        alt={`${reign.beltHolder} logo`}
+                        style={{ height: 24, marginRight: 8 }}
+                      />
+                    )}
                     <Link href={`/team/${encodeURIComponent(reign.beltHolder)}`} legacyBehavior>
                       <a>{reign.beltHolder}</a>
                     </Link>

--- a/pages/record-book.js
+++ b/pages/record-book.js
@@ -1,20 +1,34 @@
 import React from 'react';
 import NavBar from '../components/NavBar';
 import AdUnit from '../components/AdUnit';
+import Head from 'next/head';
 import { teamLogoMap, normalizeTeamName } from '../utils/teamUtils';
 import { fetchFromApi } from '../utils/ssr';
 
 export default function RecordBookPage({ data }) {
-  if (!data.length) return (
-    <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
-      <NavBar />
-      <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Record Book</h1>
-      <p style={{ marginBottom: '1rem' }}>
-        Historical highlights and statistical leaders from every College Football Belt game.
-      </p>
-      <p>No data available.</p>
-    </div>
+  const head = (
+    <Head>
+      <title>Record Book - College Football Belt</title>
+      <meta
+        name="description"
+        content="Historical highlights and statistical leaders from every College Football Belt game."
+      />
+      <meta property="og:image" content="/images/fallback-helmet.png" />
+    </Head>
   );
+
+  if (!data.length)
+    return (
+      <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
+        {head}
+        <NavBar />
+        <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Record Book</h1>
+        <p style={{ marginBottom: '1rem' }}>
+          Historical highlights and statistical leaders from every College Football Belt game.
+        </p>
+        <p>No data available.</p>
+      </div>
+    );
 
   const teamStats = {};
   const allTeams = new Set();
@@ -84,6 +98,7 @@ export default function RecordBookPage({ data }) {
 
   return (
     <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
+      {head}
       <NavBar />
 
       {/* Safe top ad: only after data is present */}

--- a/pages/team/[team].js
+++ b/pages/team/[team].js
@@ -7,6 +7,7 @@ import {
 } from '../../utils/teamUtils';
 import AdUnit from '../../components/AdUnit';
 import NavBar from '../../components/NavBar';
+import Head from 'next/head';
 import { fetchFromApi } from '../../utils/ssr';
 
 const styles = {
@@ -25,6 +26,20 @@ const styles = {
 
 export default function TeamPage({ data, team }) {
   const [expandedRows, setExpandedRows] = useState({});
+  const defaultHead = (
+    <Head>
+      <title>{team ? `${team} - College Football Belt History` : 'College Football Belt Team'}</title>
+      <meta
+        name="description"
+        content={
+          team
+            ? `Explore ${team}'s history with the College Football Belt.`
+            : 'Team information for the College Football Belt.'
+        }
+      />
+      <meta property="og:image" content="/images/fallback-helmet.png" />
+    </Head>
+  );
 
   useEffect(() => {
     if (typeof window !== 'undefined' && team) {
@@ -43,6 +58,7 @@ export default function TeamPage({ data, team }) {
           textAlign: 'center',
         }}
       >
+        {defaultHead}
         <NavBar />
         <p style={{ marginTop: '2rem' }}>No data available.</p>
         <p>Please check back later.</p>
@@ -83,6 +99,7 @@ export default function TeamPage({ data, team }) {
           textAlign: 'center',
         }}
       >
+        {defaultHead}
         <NavBar />
         <h1 style={{ fontSize: '2rem', color: '#001f3f', marginTop: '1rem' }}>
           Team not found
@@ -99,6 +116,17 @@ export default function TeamPage({ data, team }) {
   const logoUrl = logoId
     ? `https://a.espncdn.com/i/teamlogos/ncaa/500/${logoId}.png`
     : '';
+
+  const head = (
+    <Head>
+      <title>{team} - College Football Belt History</title>
+      <meta
+        name="description"
+        content={`Explore ${team}'s history with the College Football Belt.`}
+      />
+      <meta property="og:image" content={logoUrl || '/images/fallback-helmet.png'} />
+    </Head>
+  );
 
   const filteredReigns = data
     .filter((r) => normalizeTeamName(r.beltHolder) === normalizedTeam)
@@ -182,6 +210,7 @@ export default function TeamPage({ data, team }) {
         borderRadius: '8px',
       }}
     >
+      {head}
       <NavBar />
 
       {/* ✅ Gate manual ads on real data */}

--- a/pages/team/allteamsrecords.js
+++ b/pages/team/allteamsrecords.js
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { teamLogoMap, normalizeTeamName, computeRecord } from '../../utils/teamUtils';
 import NavBar from '../../components/NavBar';
 import AdUnit from '../../components/AdUnit';
+import Head from 'next/head';
 import { fetchFromApi } from '../../utils/ssr';
 
 const cleanTeamName = (name = '') =>
@@ -12,6 +13,17 @@ export default function AllTeamsRecords({ data }) {
   const [filter, setFilter] = useState('');
   const [sortKey, setSortKey] = useState('wins');
   const [sortAsc, setSortAsc] = useState(false);
+
+  const head = (
+    <Head>
+      <title>All Teams Records - College Football Belt</title>
+      <meta
+        name="description"
+        content="Search and sort every program's performance in College Football Belt history."
+      />
+      <meta property="og:image" content="/images/fallback-helmet.png" />
+    </Head>
+  );
 
   if (!data.length) {
     return (
@@ -24,6 +36,7 @@ export default function AllTeamsRecords({ data }) {
           textAlign: 'center',
         }}
       >
+        {head}
         <NavBar />
         <p style={{ marginTop: '2rem' }}>No data available.</p>
         <p>Try again later.</p>
@@ -66,6 +79,7 @@ export default function AllTeamsRecords({ data }) {
 
   return (
     <div style={{ maxWidth: '1000px', margin: '0 auto', padding: '1rem' }}>
+      {head}
       <NavBar />
 
       <div style={{ marginBottom: '1.5rem' }}>


### PR DESCRIPTION
## Summary
- ensure past reign logos on the home page include descriptive alt text
- add `og:image` support to the blog and inject description/preview metadata into record book and team pages
- introduce dynamic head metadata for individual team pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bebc4443f8833284c54db25ab1f920