### PR TITLE
Render footer globally across pages

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,6 +2,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 import Script from "next/script";
+import Footer from "../components/Footer";
 
 const PUB_ID = "ca-pub-7568133290427764"; // your AdSense publisher ID
 
@@ -84,6 +85,7 @@ export default function MyApp({ Component, pageProps }) {
          Auto-ads now loads dynamically only on allowed routes. */}
 
       <Component {...pageProps} />
+      <Footer />
     </>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,7 +5,6 @@ import NavBar from '../components/NavBar';
 import { teamLogoMap, normalizeTeamName, computeRecord } from '../utils/teamUtils';
 import Head from 'next/head';
 import AdUnit from '../components/AdUnit';
-import Footer from '../components/Footer';
 import { fetchFromApi } from '../utils/ssr';
 
 // ...inside your component render where the placeholder was:
@@ -237,7 +236,6 @@ export default function HomePage({ data }) {
 
     <div style={{ marginBottom: '1.5rem' }}>
   <AdUnit AdSlot="9168138847" enabled={data.length > 0} />
-   <Footer />
 </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- import Footer in `_app.js` and render it after each page component so the footer appears on every route
- remove index page's local Footer import to avoid duplicate footers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68beef9c52048332ba42349cb93a2b38