### PR TITLE
Add intro sections with internal links to record pages

### DIFF
--- a/pages/record-book.js
+++ b/pages/record-book.js
@@ -2,6 +2,7 @@ import React from 'react';
 import NavBar from '../components/NavBar';
 import AdUnit from '../components/AdUnit';
 import Head from 'next/head';
+import Link from 'next/link';
 import { teamLogoMap, normalizeTeamName } from '../utils/teamUtils';
 import { fetchFromApi } from '../utils/ssr';
 
@@ -107,6 +108,21 @@ export default function RecordBookPage({ data }) {
       </div>
 
       <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Record Book</h1>
+      <h2 style={{ fontSize: '1.25rem', marginBottom: '0.75rem', color: '#001f3f' }}>About the Record Book</h2>
+      <p style={{ marginBottom: '1rem' }}>
+        College Football Belt’s record book distills more than a century of championship lineage into a quick
+        reference for the curious fan. The summary at the top ranks programs by record book superlatives: the
+        longest reign, teams that have piled up wins, and those that keep falling short. Beneath those highlights,
+        the page explores broader trends. The 'Top 5 Most Played Belt Matchups' table showcases rivalries that have
+        repeatedly influenced the belt's path, revealing traditional powers and regional battles. Another list calls
+        out major FBS programs that have never captured the title, a reminder of how elusive the belt can be. Use
+        these tables alongside the <Link href="/team/allteamsrecords">All Teams Records</Link> directory to study how
+        individual schools stack up and identify surprising underperformers. For a fuller narrative about how the belt
+        originated and why fans track it, visit the <Link href="/about">about page</Link>. Together these resources
+        provide a compact yet meaningful history of the sport's most itinerant championship. Whether you're scanning
+        for the dominant dynasties or tracing obscure upsets, the record book turns decades of box scores into a
+        digestible snapshot.
+      </p>
 
       <div style={rowStyle}><strong>🏆 Longest Reign:</strong>&nbsp; {logo(longestReign.beltHolder)} {longestReign.beltHolder} with {longestReign.numberOfDefenses} defenses</div>
       <div style={rowStyle}><strong>💔 Most Losses Without a Win:</strong>&nbsp; {logo(mostLossesWithoutWin[0])} {mostLossesWithoutWin[0]} with {mostLossesWithoutWin[1].losses} losses</div>

--- a/pages/team/allteamsrecords.js
+++ b/pages/team/allteamsrecords.js
@@ -87,8 +87,17 @@ export default function AllTeamsRecords({ data }) {
       </div>
 
       <h1 style={{ textAlign: 'center', fontSize: '1.5rem', fontWeight: 'bold' }}>All Teams Records</h1>
+      <h2 style={{ textAlign: 'center', fontSize: '1.25rem', margin: '0.5rem 0', color: '#001f3f' }}>About These Team Records</h2>
       <p style={{ textAlign: 'center', marginBottom: '1rem' }}>
-        Search and sort every program's performance in College Football Belt history.
+        Every school that has participated in a College Football Belt game is cataloged below, offering a searchable
+        database of wins, losses, ties, and reigns. The table lets you filter by name, reorder by clicking any column,
+        and follow links to individual team pages for deeper dives. Comparing win percentages side by side reveals which
+        programs seized their opportunities and which let the belt slip away. Historians can trace eras of dominance or
+        drought, while newcomers gain a quick sense of the belt’s competitive landscape. Use it alongside the <Link href="/record-book">Record Book</Link> to identify standout
+        performances or surprising absences, and visit the <Link href="/about">about page</Link> for background on how the
+        belt travels from champion to champion. By centralizing every program’s belt resume, this table highlights the
+        breadth of schools touched by the title and invites fans to explore the stories behind the numbers. It is an
+        evolving ledger that grows with each new game.
       </p>
 
       <input


### PR DESCRIPTION
## Summary
- Introduce Record Book page with contextual overview and links to related resources
- Add explainer section to All Teams Records page outlining table features and significance

## Testing
- `npm test` *(fails: Missing script: "test"?)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4090c2a883328f1d736857e191f9