### PR TITLE
Handle merged x-forwarded-host headers

### DIFF
--- a/utils/ssr.js
+++ b/utils/ssr.js
@@ -2,7 +2,12 @@
 export function getBaseUrl(req) {
   const protoHeader = (req?.headers?.['x-forwarded-proto'] || '').toString();
   const proto = protoHeader.split(',')[0] || (req?.connection?.encrypted ? 'https' : 'http');
-  const host = req?.headers?.['x-forwarded-host'] || req?.headers?.host || 'localhost:3000';
+  const hostHeader = (
+    req?.headers?.['x-forwarded-host'] ||
+    req?.headers?.host ||
+    'localhost:3000'
+  ).toString();
+  const host = hostHeader.split(',')[0];
   return `${proto}://${host}`;
 }
 


### PR DESCRIPTION
## Summary
- Handle merged x-forwarded-host header values when building base URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails: Error: x Expression expected in pages/blog.js:71)*

------
https://chatgpt.com/codex/tasks/task_e_68bf41bbe6588332ac79dd40fb94840a