### PR TITLE
Add privacy, terms, and contact pages with footer links

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,5 +1,6 @@
 import { FaInstagram, FaXTwitter } from 'react-icons/fa6';
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 
 export default function Footer() {
   const [lastUpdated, setLastUpdated] = useState('');
@@ -16,7 +17,6 @@ export default function Footer() {
     }
     fetchLastUpdated();
   }, []);
-
   return (
     <footer style={styles.footer}>
       {lastUpdated && (
@@ -29,6 +29,20 @@ export default function Footer() {
           })}
         </div>
       )}
+      <div style={styles.linkRow}>
+        <Link href="/about" style={styles.link}>
+          About
+        </Link>
+        <Link href="/contact" style={styles.link}>
+          Contact
+        </Link>
+        <Link href="/privacy" style={styles.link}>
+          Privacy Policy
+        </Link>
+        <Link href="/terms" style={styles.link}>
+          Terms &amp; Conditions
+        </Link>
+      </div>
       <div style={styles.iconRow}>
         <a
           href="https://instagram.com/thecollegefootballbelt"
@@ -66,6 +80,15 @@ const styles = {
     gap: '16px',
   },
   iconLink: {
+    color: '#000',
+    textDecoration: 'none',
+  },
+  linkRow: {
+    display: 'flex',
+    gap: '12px',
+    fontSize: '0.9rem',
+  },
+  link: {
     color: '#000',
     textDecoration: 'none',
   },

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import NavBar from '../components/NavBar';
+import Head from 'next/head';
+
+export default function ContactPage() {
+  return (
+    <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
+      <Head>
+        <title>Contact - College Football Belt</title>
+        <meta
+          name="description"
+          content="Get in touch with the College Football Belt team."
+        />
+      </Head>
+      <NavBar />
+
+      <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Contact</h1>
+
+      <p style={{ marginBottom: '1rem' }}>
+        Have questions or feedback? Reach out by filling out the form below or email us directly at{' '}
+        <a href="mailto:contact@cfbbelt.com">contact@cfbbelt.com</a>.
+      </p>
+
+      <form
+        action="mailto:contact@cfbbelt.com"
+        method="post"
+        encType="text/plain"
+        style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', maxWidth: '400px' }}
+      >
+        <input
+          type="text"
+          name="name"
+          placeholder="Your Name"
+          required
+          style={{ padding: '0.5rem', border: '1px solid #ccc', borderRadius: '4px' }}
+        />
+        <input
+          type="email"
+          name="email"
+          placeholder="Your Email"
+          required
+          style={{ padding: '0.5rem', border: '1px solid #ccc', borderRadius: '4px' }}
+        />
+        <textarea
+          name="message"
+          placeholder="Your Message"
+          required
+          rows="4"
+          style={{ padding: '0.5rem', border: '1px solid #ccc', borderRadius: '4px' }}
+        ></textarea>
+        <button
+          type="submit"
+          style={{ padding: '0.5rem', backgroundColor: '#001f3f', color: '#fff', border: 'none', borderRadius: '4px', cursor: 'pointer' }}
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}
+

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import NavBar from '../components/NavBar';
+import Head from 'next/head';
+
+export default function PrivacyPage() {
+  return (
+    <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
+      <Head>
+        <title>Privacy Policy - College Football Belt</title>
+        <meta
+          name="description"
+          content="Read the privacy policy for the College Football Belt website."
+        />
+      </Head>
+      <NavBar />
+
+      <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Privacy Policy</h1>
+
+      <p style={{ marginBottom: '1rem' }}>
+        This site uses cookies and third-party services (such as Google AdSense) to display ads and track usage data. We do not collect personal information directly. You can manage your cookie settings via your browser.
+      </p>
+    </div>
+  );
+}
+

--- a/pages/terms.js
+++ b/pages/terms.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import NavBar from '../components/NavBar';
+import Head from 'next/head';
+
+export default function TermsPage() {
+  return (
+    <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
+      <Head>
+        <title>Terms & Conditions - College Football Belt</title>
+        <meta
+          name="description"
+          content="Read the terms and conditions for using the College Football Belt website."
+        />
+      </Head>
+      <NavBar />
+
+      <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Terms & Conditions</h1>
+
+      <p style={{ marginBottom: '1rem' }}>
+        By using this site, you agree to use it for informational purposes only and accept that all content is provided as-is without warranties.
+      </p>
+
+      <p style={{ marginBottom: '1rem' }}>
+        <strong>FTC Disclosure:</strong> As an Amazon Associate, I earn from qualifying purchases. This means that if you click on a link to a product on Amazon and make a purchase, I may receive a small commission at no additional cost to you.
+      </p>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add dedicated pages for privacy policy, terms & conditions, and contact
- include email and mailto form for user contact
- expose about, contact, privacy, and terms links in the site footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(setup prompt prevented completion)*
- `npm run build` *(started, cancelled before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68bf436b9ee08332a62b4c3183d8ca1b