### PR TITLE
feat: add conditional ad slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Advertising configuration
+
+This project can display either Google AdSense units or a fallback Amazon affiliate banner.
+
+Set the following environment variable to control which network is used:
+
+```
+NEXT_PUBLIC_ADSENSE_ENABLED="true" # use AdSense; any other value shows the Amazon banner
+```
+
+Enable this flag only after your AdSense account and the site have been approved. Once the flag is set to `"true"`, the AdSense script is injected dynamically and `<AdSlot>` components will render AdSense `<ins class="adsbygoogle">` slots. When the flag is not `"true"`, `<AdSlot>` instead renders the Amazon affiliate banner.

--- a/components/AdSlot.js
+++ b/components/AdSlot.js
@@ -1,0 +1,14 @@
+import React from "react";
+import AdUnit from "./AdUnit";
+import AmazonBanner from "./AmazonBanner";
+
+/**
+ * Chooses between AdSense and Amazon affiliate ads.
+ * When NEXT_PUBLIC_ADSENSE_ENABLED === "true", renders <AdUnit/>;
+ * otherwise falls back to <AmazonBanner/>.
+ */
+export default function AdSlot(props) {
+  const adsenseEnabled =
+    process.env.NEXT_PUBLIC_ADSENSE_ENABLED === "true";
+  return adsenseEnabled ? <AdUnit {...props} /> : <AmazonBanner />;
+}

--- a/components/AdUnit.js
+++ b/components/AdUnit.js
@@ -1,145 +1,43 @@
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect } from "react";
 
 /**
- * Smart AdSense unit for cfbbelt.com
- * - No page changes required:
- *   If `enabled` prop is omitted, it auto-enables when the page has "enough" content.
- * - Heuristics:
- *   - Wait until document.body innerText length >= minText (default 300 chars)
- *   - Optionally require an element to exist (e.g., "#main-content")
- *   - Then wait until the slot is in view before pushing (reduces CLS)
- *
- * Optional props you can tweak per placement:
- *   <AdUnit AdSlot="9168138847" variant="leaderboard" />
- *   <AdUnit AdSlot="123" variant="inContent" auto={{ minText: 500, selector: "#belt-table" }} />
- *
- * If you prefer explicit control, pass `enabled={boolean}` and the heuristics are skipped.
+ * Basic AdSense unit that renders the standard
+ * `<ins class="adsbygoogle">` slot. Any previously used
+ * heuristic or variant logic has been removed for a
+ * straightforward implementation.
  */
-
 export default function AdUnit({
   AdSlot,
-  slot,                             // allow either name
-  enabled,                          // if provided, overrides auto heuristics
-  variant = "leaderboard",
-  type: legacyType,
-  format: legacyFormat,
+  slot,
+  adSlot,
+  enabled = true,
   className = "",
+  style = { display: "block" },
   client = "ca-pub-7568133290427764",
-  auto = { minText: 300, selector: null },   // heuristics when enabled is undefined
+  format = "auto",
+  fullWidthResponsive = true,
 }) {
-  const ref = useRef(null);
-  const pushedRef = useRef(false);
-  const [shouldRender, setShouldRender] = useState(Boolean(enabled)); // if enabled provided, honor immediately
+  const resolvedSlot = slot || AdSlot || adSlot;
 
-  // Heuristic gate: only when enabled is not explicitly set
   useEffect(() => {
-    if (typeof enabled === "boolean") {
-      setShouldRender(enabled);
-      return;
+    if (!enabled) return;
+    try {
+      (window.adsbygoogle = window.adsbygoogle || []).push({});
+    } catch (e) {
+      // ignore errors from ad blocker or repeated pushes
     }
+  }, [enabled]);
 
-    const { minText = 300, selector = null } = auto || {};
-    const meetsText = () => (document?.body?.innerText || "").trim().length >= minText;
-    const meetsSelector = () => (selector ? !!document.querySelector(selector) : true);
-
-    // Poll a few times quickly as content hydrates
-    let tries = 0;
-    const maxTries = 40; // ~4s if 100ms
-    const timer = setInterval(() => {
-      tries += 1;
-      if (meetsText() && meetsSelector()) {
-        setShouldRender(true);
-        clearInterval(timer);
-      } else if (tries >= maxTries) {
-        // Fail-open after timeout to avoid never showing ads on slower pages
-        setShouldRender(true);
-        clearInterval(timer);
-      }
-    }, 100);
-
-    return () => clearInterval(timer);
-  }, [enabled, auto]);
-
-  useEffect(() => {
-    if (!shouldRender || !ref.current || pushedRef.current) return;
-
-    // Use IntersectionObserver to push only when visible
-    const el = ref.current;
-    const io = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (
-            entry.isIntersecting &&
-            typeof window !== "undefined" &&
-            el.getAttribute("data-adsbygoogle-status") !== "done"
-          ) {
-            try {
-              (window.adsbygoogle = window.adsbygoogle || []).push({});
-              pushedRef.current = true;
-              io.disconnect();
-            } catch {
-              // swallow; AdSense may retry later
-            }
-          }
-        });
-      },
-      { rootMargin: "200px 0px" }
-    );
-
-    io.observe(el);
-    return () => io.disconnect();
-  }, [shouldRender]);
-
-  // Variant resolution (back-compat with your legacy props)
-  const resolvedVariant = (legacyType || legacyFormat || variant || "leaderboard")
-    .toLowerCase()
-    .includes("content")
-    ? "inContent"
-    : "leaderboard";
-
-  const preset = presets[resolvedVariant] || presets.leaderboard;
-  const resolvedSlot = slot || AdSlot;
-
-  // Do not render any ad markup until heuristics say “ready”
-  if (!shouldRender) return null;
+  if (!enabled || !resolvedSlot) return null;
 
   return (
-    <div className={`${preset.wrapper} ${className}`}>
-      <ins
-        ref={ref}
-        className={`adsbygoogle ${preset.ins}`}
-        style={preset.style}
-        data-ad-client={client}
-        data-ad-slot={resolvedSlot}
-        data-ad-format={preset.dataAdFormat}
-        data-full-width-responsive={preset.fullWidthResponsive}
-      />
-      <style jsx>{`
-        .wrapper { width: 100%; display: block; margin: 0 auto; }
-        .leaderboard { max-width: 728px; min-height: 90px; }
-        @media (max-width: 1024px) { .leaderboard { max-width: 468px; min-height: 60px; } }
-        @media (max-width: 640px)  { .leaderboard { max-width: 320px; min-height: 100px; } }
-        .incontent { max-width: 336px; min-height: 280px; }
-        @media (max-width: 1024px) { .incontent { max-width: 300px; min-height: 250px; } }
-        @media (max-width: 400px)  { .incontent { max-width: 300px; min-height: 250px; } }
-      `}</style>
-    </div>
+    <ins
+      className={`adsbygoogle ${className}`.trim()}
+      style={style}
+      data-ad-client={client}
+      data-ad-slot={resolvedSlot}
+      data-ad-format={format}
+      data-full-width-responsive={fullWidthResponsive ? "true" : "false"}
+    />
   );
 }
-
-const presets = {
-  leaderboard: {
-    wrapper: "wrapper",
-    ins: "leaderboard",
-    dataAdFormat: "horizontal",
-    fullWidthResponsive: "false",
-    style: { display: "block" },
-  },
-  inContent: {
-    wrapper: "wrapper",
-    ins: "incontent",
-    dataAdFormat: "auto",
-    fullWidthResponsive: "false",
-    style: { display: "block" },
-  },
-};

--- a/components/AmazonBanner.js
+++ b/components/AmazonBanner.js
@@ -1,0 +1,21 @@
+import React from "react";
+
+/**
+ * Simple Amazon affiliate banner.
+ * Replace the iframe `src` with your own Amazon Associates banner code.
+ */
+export default function AmazonBanner() {
+  return (
+    <div style={{ textAlign: "center", margin: "1rem 0" }}>
+      <iframe
+        title="Amazon Banner"
+        src="https://rcm-na.amazon-adsystem.com/e/cm?o=1&p=48&l=ur1&category=sports&banner=1Y0KEQF9WFA8VYHDR8R2&f=ifr&linkID=&t=cfbbelt-20&tracking_id=cfbbelt-20"
+        width="728"
+        height="90"
+        scrolling="no"
+        style={{ border: "none" }}
+        frameBorder="0"
+      />
+    </div>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,6 +5,7 @@ import Script from "next/script";
 import Footer from "../components/Footer";
 
 const PUB_ID = "ca-pub-7568133290427764"; // your AdSense publisher ID
+const ADSENSE_ENABLED = process.env.NEXT_PUBLIC_ADSENSE_ENABLED === "true";
 
 // Routes where Auto Ads must NEVER initialize
 const AUTO_ADS_BLOCKLIST = [
@@ -25,6 +26,7 @@ function isBlocked(pathname) {
 }
 
 function ensureAutoAdsLoaded(pubId) {
+  if (!ADSENSE_ENABLED) return;
   // Skip if the page has no meaningful text content
   const bodyText = (document?.body?.innerText || "").trim();
   if (!bodyText.length) return;
@@ -47,6 +49,7 @@ export default function MyApp({ Component, pageProps }) {
   const { hasContent = true } = pageProps;
 
   useEffect(() => {
+    if (!ADSENSE_ENABLED) return;
     const handle = (url) => {
       const bodyText = (document?.body?.innerText || "").trim();
       const contentPresent =

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import NavBar from '../components/NavBar';
 import Head from 'next/head';
+import AdSlot from '../components/AdSlot';
 
 export default function AboutPage() {
   return (
@@ -53,6 +54,9 @@ export default function AboutPage() {
 <p style={{ marginTop: '2rem', fontSize: '0.9rem', color: '#555' }}>
   <strong>FTC Disclosure:</strong> As an Amazon Associate, I earn from qualifying purchases. This means that if you click on a link to a product on Amazon and make a purchase, I may receive a small commission at no additional cost to you.
 </p>
+      <div style={{ margin: '1.5rem 0' }}>
+        <AdSlot AdSlot="9168138847" />
+      </div>
     </div>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,7 +4,7 @@ import { useRouter } from 'next/router';
 import NavBar from '../components/NavBar';
 import { teamLogoMap, normalizeTeamName, computeRecord } from '../utils/teamUtils';
 import Head from 'next/head';
-import AdUnit from '../components/AdUnit';
+import AdSlot from '../components/AdSlot';
 import { fetchFromApi } from '../utils/ssr';
 
 // ...inside your component render where the placeholder was:
@@ -132,7 +132,7 @@ export default function HomePage({ data }) {
     <NavBar />
 
     <div style={{ marginBottom: '1.5rem' }}>
-  <AdUnit AdSlot="9168138847" enabled={data.length > 0} />
+  <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
 </div>
 
       <div style={{ textAlign: 'center', marginBottom: '0.25rem' }}>
@@ -271,7 +271,7 @@ export default function HomePage({ data }) {
       <div style={{ marginTop: '1rem' }}>{getPagination()}</div>
 
     <div style={{ marginBottom: '1.5rem' }}>
-  <AdUnit AdSlot="9168138847" enabled={data.length > 0} />
+  <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
 </div>
     </div>
   );

--- a/pages/record-book.js
+++ b/pages/record-book.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import NavBar from '../components/NavBar';
-import AdUnit from '../components/AdUnit';
+import AdSlot from '../components/AdSlot';
 import Head from 'next/head';
 import Link from 'next/link';
 import { teamLogoMap, normalizeTeamName } from '../utils/teamUtils';
@@ -104,7 +104,7 @@ export default function RecordBookPage({ data }) {
 
       {/* Safe top ad: only after data is present */}
       <div style={{ margin: '1rem 0' }}>
-        <AdUnit AdSlot="9168138847" enabled={data.length > 0} />
+        <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
       </div>
 
       <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Record Book</h1>
@@ -152,7 +152,7 @@ export default function RecordBookPage({ data }) {
 
       {/* Safe bottom ad: only after data is present */}
       <div style={{ margin: '1.5rem 0' }}>
-      <AdUnit AdSlot="9168138847" enabled={data.length > 0} />
+      <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
       </div>
     </div>
   );

--- a/pages/team/[team].js
+++ b/pages/team/[team].js
@@ -5,7 +5,7 @@ import {
   computeRecord,
   debugTeamGames,
 } from '../../utils/teamUtils';
-import AdUnit from '../../components/AdUnit';
+import AdSlot from '../../components/AdSlot';
 import NavBar from '../../components/NavBar';
 import Head from 'next/head';
 import { fetchFromApi } from '../../utils/ssr';
@@ -215,7 +215,7 @@ export default function TeamPage({ data, team }) {
 
       {/* ✅ Gate manual ads on real data */}
       <div style={{ marginBottom: '1.5rem' }}>
-        <AdUnit AdSlot="9168138847" enabled={data.length > 0} />
+        <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
       </div>
 
       <div style={{ textAlign: 'center', marginBottom: '1.5rem' }}>
@@ -348,7 +348,7 @@ export default function TeamPage({ data, team }) {
       </div>
 
       <div style={{ marginBottom: '1.5rem' }}>
-      <AdUnit AdSlot="9168138847" enabled={data.length > 0} />
+      <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
       </div>
     </div>
   );

--- a/pages/team/allteamsrecords.js
+++ b/pages/team/allteamsrecords.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import Link from 'next/link';
 import { teamLogoMap, normalizeTeamName, computeRecord } from '../../utils/teamUtils';
 import NavBar from '../../components/NavBar';
-import AdUnit from '../../components/AdUnit';
+import AdSlot from '../../components/AdSlot';
 import Head from 'next/head';
 import { fetchFromApi } from '../../utils/ssr';
 
@@ -83,7 +83,7 @@ export default function AllTeamsRecords({ data }) {
       <NavBar />
 
       <div style={{ marginBottom: '1.5rem' }}>
-        <AdUnit AdSlot="9168138847" variant="leaderboard" enabled={data.length > 0} />
+        <AdSlot AdSlot="9168138847" variant="leaderboard" enabled={data.length > 0} />
       </div>
 
       <h1 style={{ textAlign: 'center', fontSize: '1.5rem', fontWeight: 'bold' }}>All Teams Records</h1>
@@ -143,7 +143,7 @@ export default function AllTeamsRecords({ data }) {
       })}
 
       <div style={{ margin: '1.5rem 0' }}>
-        <AdUnit AdSlot="9168138847" variant="leaderboard" enabled={data.length > 0} />
+        <AdSlot AdSlot="9168138847" variant="leaderboard" enabled={data.length > 0} />
       </div>
 
       <style jsx>{`


### PR DESCRIPTION
## Summary
- restore basic AdSense `<ins>` AdUnit implementation
- add AdSlot component to switch between AdSense and Amazon ads via `NEXT_PUBLIC_ADSENSE_ENABLED`
- conditionally load AdSense script and document new flag

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build` (fails: unable to find next-sitemap.config.js)


------
https://chatgpt.com/codex/tasks/task_e_68c04bd3a1f4833297504ab3663f83ef