### PR TITLE
Resize Amazon banner and reposition newsletter

### DIFF
--- a/components/AmazonBanner.js
+++ b/components/AmazonBanner.js
@@ -6,7 +6,7 @@ import React from "react";
  */
 export default function AmazonBanner() {
   return (
-    <div className="flex flex-wrap justify-center gap-4 my-4">
+    <div className="flex flex-wrap justify-center gap-2 my-2">
       <a
         href="https://amzn.to/4gmUa7I"
         target="_blank"
@@ -15,18 +15,18 @@ export default function AmazonBanner() {
       >
         <svg
           width="300"
-          height="150"
+          height="100"
           xmlns="http://www.w3.org/2000/svg"
           className="block max-w-full"
         >
-          <rect width="300" height="150" fill="#006747" />
+          <rect width="300" height="100" fill="#006747" />
           <text
             x="50%"
             y="50%"
             dominantBaseline="middle"
             textAnchor="middle"
             fontFamily="Arial"
-            fontSize="24"
+            fontSize="20"
             fill="#ffffff"
           >
             USF Bulls Gear
@@ -42,18 +42,18 @@ export default function AmazonBanner() {
       >
         <svg
           width="300"
-          height="150"
+          height="100"
           xmlns="http://www.w3.org/2000/svg"
           className="block max-w-full"
         >
-          <rect width="300" height="150" fill="#c0a16b" />
+          <rect width="300" height="100" fill="#c0a16b" />
           <text
             x="50%"
             y="50%"
             dominantBaseline="middle"
             textAnchor="middle"
             fontFamily="Arial"
-            fontSize="24"
+            fontSize="20"
             fill="#000000"
           >
             Fantasy Football Belts
@@ -69,18 +69,18 @@ export default function AmazonBanner() {
       >
         <svg
           width="300"
-          height="150"
+          height="100"
           xmlns="http://www.w3.org/2000/svg"
           className="block max-w-full"
         >
-          <rect width="300" height="150" fill="#f47321" />
+          <rect width="300" height="100" fill="#f47321" />
           <text
             x="50%"
             y="50%"
             dominantBaseline="middle"
             textAnchor="middle"
             fontFamily="Arial"
-            fontSize="24"
+            fontSize="20"
             fill="#ffffff"
           >
             Miami Hurricanes Gear

--- a/components/NewsletterSignup.js
+++ b/components/NewsletterSignup.js
@@ -32,7 +32,7 @@ export default function NewsletterSignup() {
   return (
     <div style={{ margin: '2rem 0' }}>
       <h2 style={{ fontSize: '1.5rem', marginBottom: '0.75rem', color: '#001f3f' }}>
-        Newsletter Signup
+        Stay on top of which team has the CFB Belt: Sign up for our newsletter!
       </h2>
       <form onSubmit={handleSubmit} style={{ display: 'flex', gap: '0.5rem' }}>
         <input

--- a/pages/index.js
+++ b/pages/index.js
@@ -136,6 +136,8 @@ export default function HomePage({ data }) {
   <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
 </div>
 
+      <NewsletterSignup />
+
       <div style={{ textAlign: 'center', marginBottom: '0.25rem' }}>
         <h1 style={{ fontSize: '2rem', margin: 0, color: '#001f3f' }}>The College Football Belt</h1>
         <div style={{ fontSize: '1.5rem', fontStyle: 'italic', color: '#666', marginTop: '0.5rem' }}>Next Game</div>
@@ -224,8 +226,6 @@ export default function HomePage({ data }) {
           classic reign, the goal is to offer a central hub for the stories and statistics that define the College Football Belt.
         </p>
       </section>
-
-      <NewsletterSignup />
 
       <h2 style={{ fontSize: '1.5rem', marginBottom: '0.75rem', color: '#001f3f' }}>
         Past Belt Reigns


### PR DESCRIPTION
## Summary
- Shrink Amazon affiliate banner height while keeping full width
- Move newsletter signup under ad slot with engaging text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e4687dbc833293f56d56c58c683e