### PR TITLE
Remove AmazonBanner from NavBar

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -1,6 +1,5 @@
 // components/NavBar.js
 import Link from 'next/link';
-import AmazonBanner from './AmazonBanner';
 
 export default function NavBar() {
   const links = [
@@ -31,7 +30,6 @@ export default function NavBar() {
           Buy CFB Belts
         </a>
       </nav>
-      <AmazonBanner />
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- remove unused AmazonBanner import and component from NavBar to avoid duplicate ads

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68c2f29f15b883329133cecd0a6dded0