### PR TITLE
Improve header styling and ad spacing

### DIFF
--- a/components/AmazonBanner.js
+++ b/components/AmazonBanner.js
@@ -6,7 +6,7 @@ import React from "react";
  */
 export default function AmazonBanner() {
   return (
-    <div className="flex flex-wrap justify-center gap-2 my-2">
+    <div className="flex flex-wrap justify-center gap-2 mt-8 mb-4">
       <a
         href="https://amzn.to/4gmUa7I"
         target="_blank"

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -3,48 +3,50 @@ import Link from 'next/link';
 
 export default function NavBar() {
   const links = [
-    { href: '/', label: 'Home', className: 'text-xl font-bold' },
-    { href: '/team/allteamsrecords', label: 'All Teams Records', className: '' },
-    { href: '/about', label: 'About', className: '' },
-    { href: '/record-book', label: 'Record Book', className: '' },
+    { href: '/team/allteamsrecords', label: 'All Teams Records' },
+    { href: '/about', label: 'About' },
+    { href: '/record-book', label: 'Record Book' },
     {
       href: '/path-to-conference',
       label: 'Path To Other Conferences',
-      className: '',
     },
-    { href: '/blog', label: 'Blog', className: '' },
+    { href: '/blog', label: 'Blog' },
     {
       href: 'https://amzn.to/46M42Fs',
       label: 'Buy CFB Belts',
-      className: '',
       external: true,
     },
   ];
 
   return (
-    <header className="bg-gradient-to-r from-gray-800 to-gray-900 text-white shadow-lg mb-6">
-      <nav className="max-w-7xl mx-auto px-4 py-4 flex flex-wrap items-center justify-center gap-6 text-sm sm:text-base">
-        {links.map(({ href, label, className, external }) =>
-          external ? (
-            <a
-              key={href}
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={`${className || ''} hover:text-yellow-400 transition-colors`}
-            >
-              {label}
-            </a>
-          ) : (
-            <Link
-              key={href}
-              href={href}
-              className={`${className || ''} hover:text-yellow-400 transition-colors`}
-            >
-              {label}
-            </Link>
-          ),
-        )}
+    <header className="bg-gradient-to-r from-gray-800 to-gray-900 text-white shadow-lg mb-8">
+      <nav className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
+        <Link href="/" className="text-2xl font-semibold">
+          College Football Belt
+        </Link>
+        <ul className="flex flex-wrap items-center gap-6 text-sm sm:text-base">
+          {links.map(({ href, label, external }) => (
+            <li key={href}>
+              {external ? (
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-yellow-400 transition-colors"
+                >
+                  {label}
+                </a>
+              ) : (
+                <Link
+                  href={href}
+                  className="hover:text-yellow-400 transition-colors"
+                >
+                  {label}
+                </Link>
+              )}
+            </li>
+          ))}
+        </ul>
       </nav>
     </header>
   );


### PR DESCRIPTION
## Summary
- Redesign navigation header with brand title, balanced layout and increased bottom margin for better separation from content
- Add explicit top and bottom margins to Amazon banner to create clear spacing around the affiliate ads

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c30974316c8332bb9e0ce3dd250ccf