### PR TITLE
fix tailwind postcss plugin for Next.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
+    "@tailwindcss/postcss": "^4.1.11",
     "typescript": "^5"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,7 @@
 // postcss.config.js
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
## Summary
- use `@tailwindcss/postcss` instead of bundling Tailwind directly
- document the plugin in devDependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(could not run: `next lint` requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c32bf11a0883329ad904b61c54b892