### PR TITLE
chore: remove unavailable quick-lru dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,18 +26,6 @@
         "typescript": "^5"
       }
     },
-    "node_modules/@alloc/quick-lru": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@corex/deepmerge": {
       "version": "4.0.43",
       "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
@@ -1027,7 +1015,6 @@
       "integrity": "sha512-HLgx6YSFKJT7rJqh9oJs/TkBFhxuMOfUKSBEPYwV+t78POOBsdQ7crhZLzwcH3T0UyUuOzU/GK5pk5eKr3wCiQ==",
       "dev": true,
       "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.1.13",
         "@tailwindcss/oxide": "4.1.13",
         "postcss": "^8.4.41",


### PR DESCRIPTION
## Summary
- remove `@alloc/quick-lru` references from `package-lock.json` to avoid fetching an unavailable version

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c468eef4888332bca56f10579e8b3e