### PR TITLE
fix: use dedicated Tailwind PostCSS plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "postbuild": "next-sitemap"
+    "lint": "next lint"
   },
   "dependencies": {
     "csv-parse": "^5.6.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,7 @@
 // postcss.config.js
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
## Summary
- use @tailwindcss/postcss plugin
- remove postbuild script that ran next-sitemap

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c46d3e29fc8332b80f7a1790723f97