### PR TITLE
fix: use dedicated Tailwind PostCSS plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-icons": "^5.5.0"
       },
       "devDependencies": {
+        "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/postcss": "^4.1.13",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -24,6 +25,18 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.11",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@corex/deepmerge": {
@@ -1015,6 +1028,7 @@
       "integrity": "sha512-HLgx6YSFKJT7rJqh9oJs/TkBFhxuMOfUKSBEPYwV+t78POOBsdQ7crhZLzwcH3T0UyUuOzU/GK5pk5eKr3wCiQ==",
       "dev": true,
       "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.1.13",
         "@tailwindcss/oxide": "4.1.13",
         "postcss": "^8.4.41",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "postbuild": "next-sitemap"
+    "lint": "next lint"
   },
   "dependencies": {
     "csv-parse": "^5.6.0",
@@ -18,6 +17,7 @@
     "react-icons": "^5.5.0"
   },
   "devDependencies": {
+    "@alloc/quick-lru": "^5.2.0",
     "@tailwindcss/postcss": "^4.1.13",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,7 @@
 // postcss.config.js
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
## Summary
- use @tailwindcss/postcss plugin
- remove postbuild script that ran next-sitemap
- add explicit @alloc/quick-lru dev dependency and lockfile entry to ensure plugin resolves

## Testing
- `npm install`
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(interrupted after collecting build traces)*

------
https://chatgpt.com/codex/tasks/task_e_68c46d3e29fc8332b80f7a1790723f97