### PR TITLE
Refine NavBar spacing

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -17,11 +17,11 @@ export default function NavBar() {
 
   return (
     <nav className="w-full bg-white border-b border-gray-200 text-gray-800">
-      <div className="flex h-12 items-center justify-between px-4 sm:px-6">
+      <div className="flex h-12 items-center px-4 sm:px-6">
         <Link href="/" className="text-xl font-semibold">
           College Football Belt
         </Link>
-        <div className="flex space-x-6">
+        <div className="ml-6 flex space-x-6">
           {links.map(({ href, label, external }) => (
             external ? (
               <a


### PR DESCRIPTION
## Summary
- Adjust NavBar layout to keep branding and links grouped without excessive gap

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c483955a7c8332ac9628e059c25eca