### PR TITLE
feat: add css-based navbar

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -1,5 +1,6 @@
 // components/NavBar.js
 import Link from 'next/link';
+import styles from './NavBar.module.css';
 
 export default function NavBar() {
   const links = [
@@ -17,16 +18,12 @@ export default function NavBar() {
 
   return (
 
-    <nav className="w-full border-b border-gray-700 bg-gray-900 text-white">
-      <div className="flex h-14 items-center px-4 sm:px-6">
-        <Link
-          href="/"
-          className="text-2xl font-bold no-underline text-white transition-colors hover:text-gray-300"
-        >
+    <nav className={styles.nav}>
+      <div className={styles.container}>
+        <Link href="/" className={styles.logo}>
           College Football Belt
         </Link>
-        <ul className="ml-8 flex list-none items-center gap-6 pl-0">
-
+        <ul className={styles.links}>
           {links.map(({ href, label, external }) => (
             <li key={href}>
               {external ? (
@@ -34,15 +31,12 @@ export default function NavBar() {
                   href={href}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="rounded-md px-3 py-2 text-sm font-medium text-gray-200 no-underline transition-colors hover:bg-gray-800 hover:text-white"
+                  className={styles.link}
                 >
                   {label}
                 </a>
               ) : (
-                <Link
-                  href={href}
-                  className="rounded-md px-3 py-2 text-sm font-medium text-gray-200 no-underline transition-colors hover:bg-gray-800 hover:text-white"
-                >
+                <Link href={href} className={styles.link}>
                   {label}
                 </Link>
               )}

--- a/components/NavBar.module.css
+++ b/components/NavBar.module.css
@@ -1,0 +1,55 @@
+.nav {
+  width: 100%;
+  border-bottom: 1px solid #374151; /* gray-700 */
+  background-color: #111827; /* gray-900 */
+  color: #fff;
+}
+
+.container {
+  display: flex;
+  align-items: center;
+  height: 56px; /* h-14 */
+  padding: 0 1rem; /* px-4 */
+}
+
+.logo {
+  font-size: 1.5rem; /* text-2xl */
+  font-weight: 700;
+  text-decoration: none;
+  color: inherit;
+  transition: color 0.2s;
+}
+
+.logo:hover {
+  color: #d1d5db; /* gray-300 */
+}
+
+.links {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem; /* gap-6 */
+  margin-left: 2rem; /* ml-8 */
+  padding-left: 0;
+}
+
+.link {
+  display: inline-block;
+  padding: 0.5rem 0.75rem; /* px-3 py-2 */
+  font-size: 0.875rem; /* text-sm */
+  font-weight: 500; /* font-medium */
+  color: #e5e7eb; /* gray-200 */
+  text-decoration: none;
+  border-radius: 0.375rem; /* rounded-md */
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.link:hover {
+  background-color: #1f2937; /* gray-800 */
+  color: #fff;
+}
+
+@media (min-width: 640px) {
+  .container {
+    padding: 0 1.5rem; /* sm:px-6 */
+  }
+}


### PR DESCRIPTION
## Summary
- replace Tailwind NavBar with CSS module styling for a modern layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive prompt)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4907274988332bfff04a66f7c8f7d