### PR TITLE
Make navbar full width and adjust spacing

### DIFF
--- a/components/NavBar.module.css
+++ b/components/NavBar.module.css
@@ -3,6 +3,7 @@
   border-bottom: 1px solid #374151; /* gray-700 */
   background-color: #111827; /* gray-900 */
   color: #fff;
+  margin-bottom: 1rem;
 }
 
 .container {
@@ -41,6 +42,7 @@
   text-decoration: none;
   border-radius: 0.375rem; /* rounded-md */
   transition: background-color 0.2s, color 0.2s;
+  white-space: nowrap;
 }
 
 .link:hover {

--- a/pages/about.js
+++ b/pages/about.js
@@ -5,58 +5,60 @@ import AdSlot from '../components/AdSlot';
 
 export default function AboutPage() {
   return (
-    <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
-      <Head>
-        <title>About - College Football Belt</title>
-        <meta
-          name="description"
-          content="Learn about the College Football Belt project, its history, and how to support the site."
-        />
-      </Head>
+    <>
       <NavBar />
+      <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
+        <Head>
+          <title>About - College Football Belt</title>
+          <meta
+            name="description"
+            content="Learn about the College Football Belt project, its history, and how to support the site."
+          />
+        </Head>
 
-      <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>About the College Football Belt</h1>
+        <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>About the College Football Belt</h1>
 
-      <p style={{ marginBottom: '1rem' }}>
-        This site tracks the College Football Belt — an unofficial title passed from team to team whenever the current holder loses. Inspired by the original website and the passionate fans who kept it alive on Reddit and Twitter, I wanted to bring back a fully featured, modern version.
-      </p>
-
-      <p style={{ marginBottom: '1rem' }}>
-        I’ve built this site on nights and weekends, combining my love for college football with my background in data and web development. The goal is to make the Belt more accessible and engaging — with stats, history, and predictive features all in one place.
-      </p>
         <p style={{ marginBottom: '1rem' }}>
-        If you ever need to contact me for any reason feel free to 📨 email me at <a href="mailto:contact@cfbbelt.com">contact@cfbbelt.com</a>
-      </p>
-      
+          This site tracks the College Football Belt — an unofficial title passed from team to team whenever the current holder loses. Inspired by the original website and the passionate fans who kept it alive on Reddit and Twitter, I wanted to bring back a fully featured, modern version.
+        </p>
 
-      <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Support the Site</h2>
+        <p style={{ marginBottom: '1rem' }}>
+          I’ve built this site on nights and weekends, combining my love for college football with my background in data and web development. The goal is to make the Belt more accessible and engaging — with stats, history, and predictive features all in one place.
+        </p>
+        <p style={{ marginBottom: '1rem' }}>
+          If you ever need to contact me for any reason feel free to 📨 email me at <a href="mailto:contact@cfbbelt.com">contact@cfbbelt.com</a>
+        </p>
 
-      <p style={{ marginBottom: '1rem' }}>
-        If you enjoy the site and want to help with hosting and development costs — or just buy me a coffee — I’d really appreciate it.
-      </p>
 
-      <ul>
-        <li style={{ marginBottom: '0.5rem' }}>
-          💵 <a href="https://www.buymeacoffee.com/cfbbelt" target="_blank" rel="noopener noreferrer">Buy Me a Coffee</a>
-        </li>
-       
-      </ul>
+        <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Support the Site</h2>
 
-      <p style={{ marginTop: '2rem', fontSize: '0.9rem', color: '#666' }}>
-        Thanks for visiting — and long live the Belt.
-      </p>
-      <div style={{ marginTop: '2rem', fontSize: '0.9rem', color: '#444' }}>
-  <h3>Privacy Policy</h3>
-  <p>
-    This site uses cookies and third-party services (such as Google AdSense) to display ads and track usage data. We do not collect personal information directly. You can manage your cookie settings via your browser.
+        <p style={{ marginBottom: '1rem' }}>
+          If you enjoy the site and want to help with hosting and development costs — or just buy me a coffee — I’d really appreciate it.
+        </p>
+
+        <ul>
+          <li style={{ marginBottom: '0.5rem' }}>
+            💵 <a href="https://www.buymeacoffee.com/cfbbelt" target="_blank" rel="noopener noreferrer">Buy Me a Coffee</a>
+          </li>
+
+        </ul>
+
+        <p style={{ marginTop: '2rem', fontSize: '0.9rem', color: '#666' }}>
+          Thanks for visiting — and long live the Belt.
+        </p>
+        <div style={{ marginTop: '2rem', fontSize: '0.9rem', color: '#444' }}>
+    <h3>Privacy Policy</h3>
+    <p>
+      This site uses cookies and third-party services (such as Google AdSense) to display ads and track usage data. We do not collect personal information directly. You can manage your cookie settings via your browser.
+    </p>
+  </div>
+  <p style={{ marginTop: '2rem', fontSize: '0.9rem', color: '#555' }}>
+    <strong>FTC Disclosure:</strong> As an Amazon Associate, I earn from qualifying purchases. This means that if you click on a link to a product on Amazon and make a purchase, I may receive a small commission at no additional cost to you.
   </p>
-</div>
-<p style={{ marginTop: '2rem', fontSize: '0.9rem', color: '#555' }}>
-  <strong>FTC Disclosure:</strong> As an Amazon Associate, I earn from qualifying purchases. This means that if you click on a link to a product on Amazon and make a purchase, I may receive a small commission at no additional cost to you.
-</p>
-      <div style={{ margin: '1.5rem 0' }}>
-        <AdSlot AdSlot="9168138847" />
+        <div style={{ margin: '1.5rem 0' }}>
+          <AdSlot AdSlot="9168138847" />
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -4,16 +4,16 @@ import Head from 'next/head';
 
 export default function Blog() {
   return (
-    <div style={{ maxWidth: '800px', margin: '0 auto', padding: '1rem' }}>
-      <Head>
-        <title>CFB Belt Blog</title>
-        <meta name="description" content="Follow the latest updates and insights about the College Football Belt." />
-        <meta property="og:image" content="/images/2025week1.png" />
-      </Head>
-
+    <>
       <NavBar />
+      <div style={{ maxWidth: '800px', margin: '0 auto', padding: '1rem' }}>
+        <Head>
+          <title>CFB Belt Blog</title>
+          <meta name="description" content="Follow the latest updates and insights about the College Football Belt." />
+          <meta property="og:image" content="/images/2025week1.png" />
+        </Head>
 
-      <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>College Football Belt Blog</h1>
+        <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>College Football Belt Blog</h1>
 
       {/* Most recent post first */}
       <article style={{ marginBottom: '3rem' }}>
@@ -127,6 +127,7 @@ export default function Blog() {
 
       
       </article>
-    </div>
+      </div>
+    </>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -32,19 +32,21 @@ export default function HomePage({ data }) {
 
   if (!data.length) {
     return (
-      <div
-        style={{
-          maxWidth: 700,
-          margin: '2rem auto',
-          padding: '1rem',
-          fontFamily: 'Arial, sans-serif',
-          textAlign: 'center',
-        }}
-      >
+      <>
         <NavBar />
-        <p style={{ marginTop: '2rem' }}>No data available.</p>
-        <p>Please check back later for updated belt information.</p>
-      </div>
+        <div
+          style={{
+            maxWidth: 700,
+            margin: '2rem auto',
+            padding: '1rem',
+            fontFamily: 'Arial, sans-serif',
+            textAlign: 'center',
+          }}
+        >
+          <p style={{ marginTop: '2rem' }}>No data available.</p>
+          <p>Please check back later for updated belt information.</p>
+        </div>
+      </>
     );
   }
 
@@ -117,24 +119,25 @@ export default function HomePage({ data }) {
   return (
     
     
-    <div style={{ maxWidth: 900, margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
-       <Head>
-      <title>College Football Belt – The Lineal Title Tracker</title>
-      <meta
-        name="description"
-        content="Track the history, reigns, and future path of the College Football Belt – the lineal championship of college football."
-      />
-      <meta property="og:title" content="College Football Belt – CFB Lineal Championship" />
-      <meta property="og:description" content="See which team holds the College Football Belt, explore historical reigns, and follow its potential path." />
-      <meta property="og:image" content="/images/fallback-helmet.png" />
-      <meta property="og:url" content="https://your-domain.com" />
-      <meta name="twitter:card" content="summary_large_image" />
-    </Head>
-    <NavBar />
+    <>
+      <NavBar />
+      <div style={{ maxWidth: 900, margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
+         <Head>
+        <title>College Football Belt – The Lineal Title Tracker</title>
+        <meta
+          name="description"
+          content="Track the history, reigns, and future path of the College Football Belt – the lineal championship of college football."
+        />
+        <meta property="og:title" content="College Football Belt – CFB Lineal Championship" />
+        <meta property="og:description" content="See which team holds the College Football Belt, explore historical reigns, and follow its potential path." />
+        <meta property="og:image" content="/images/fallback-helmet.png" />
+        <meta property="og:url" content="https://your-domain.com" />
+        <meta name="twitter:card" content="summary_large_image" />
+      </Head>
 
-    <div style={{ marginBottom: '1.5rem' }}>
-  <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
-</div>
+      <div style={{ marginBottom: '1.5rem' }}>
+        <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
+      </div>
 
       <NewsletterSignup />
 
@@ -272,9 +275,10 @@ export default function HomePage({ data }) {
       <div style={{ marginTop: '1rem' }}>{getPagination()}</div>
 
     <div style={{ marginBottom: '1.5rem' }}>
-  <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
-</div>
+      <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
     </div>
+      </div>
+    </>
   );
 }
 

--- a/pages/path-to-conference.js
+++ b/pages/path-to-conference.js
@@ -4,16 +4,17 @@ import Head from 'next/head';
 
 export default function PathToConference() {
   return (
-    <div style={{ maxWidth: '900px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
-      <Head>
-        <title>Path to the Conferences - College Football Belt</title>
-        <meta
-          name="description"
-          content="See how the College Football Belt could move into each conference during the 2025 season."
-        />
-      </Head>
+    <>
       <NavBar />
-      <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Path to the Conferences</h1>
+      <div style={{ maxWidth: '900px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
+        <Head>
+          <title>Path to the Conferences - College Football Belt</title>
+          <meta
+            name="description"
+            content="See how the College Football Belt could move into each conference during the 2025 season."
+          />
+        </Head>
+        <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Path to the Conferences</h1>
 
       <p style={{ fontSize: '1rem', marginBottom: '1rem' }}>
         This page tracks the most likely way the belt could end up in each major conference during the 2025 season, based on Florida's current possession of the belt and their schedule. Bowl games and playoffs are not included.
@@ -45,9 +46,10 @@ export default function PathToConference() {
         The belt is currently in the AAC.
       </p>
 
-      <div style={{ marginTop: '2rem', fontStyle: 'italic', color: '#444' }}>
-        Belt movement is based on real schedules and historical team strength. This page will update as the season progresses.
+        <div style={{ marginTop: '2rem', fontStyle: 'italic', color: '#444' }}>
+          Belt movement is based on real schedules and historical team strength. This page will update as the season progresses.
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/pages/record-book.js
+++ b/pages/record-book.js
@@ -20,15 +20,17 @@ export default function RecordBookPage({ data }) {
 
   if (!data.length)
     return (
-      <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
-        {head}
+      <>
         <NavBar />
-        <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Record Book</h1>
-        <p style={{ marginBottom: '1rem' }}>
-          Historical highlights and statistical leaders from every College Football Belt game.
-        </p>
-        <p>No data available.</p>
-      </div>
+        <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
+          {head}
+          <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Record Book</h1>
+          <p style={{ marginBottom: '1rem' }}>
+            Historical highlights and statistical leaders from every College Football Belt game.
+          </p>
+          <p>No data available.</p>
+        </div>
+      </>
     );
 
   const teamStats = {};
@@ -98,16 +100,17 @@ export default function RecordBookPage({ data }) {
   };
 
   return (
-    <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
-      {head}
+    <>
       <NavBar />
+      <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
+        {head}
 
-      {/* Safe top ad: only after data is present */}
-      <div style={{ margin: '1rem 0' }}>
-        <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
-      </div>
+        {/* Safe top ad: only after data is present */}
+        <div style={{ margin: '1rem 0' }}>
+          <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
+        </div>
 
-      <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Record Book</h1>
+        <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Record Book</h1>
       <h2 style={{ fontSize: '1.25rem', marginBottom: '0.75rem', color: '#001f3f' }}>About the Record Book</h2>
       <p style={{ marginBottom: '1rem' }}>
         College Football Belt’s record book distills more than a century of championship lineage into a quick
@@ -151,10 +154,11 @@ export default function RecordBookPage({ data }) {
       </div>
 
       {/* Safe bottom ad: only after data is present */}
-      <div style={{ margin: '1.5rem 0' }}>
-      <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
+        <div style={{ margin: '1.5rem 0' }}>
+          <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/pages/team/[team].js
+++ b/pages/team/[team].js
@@ -49,20 +49,22 @@ export default function TeamPage({ data, team }) {
 
   if (!data.length || !team) {
     return (
-      <div
-        style={{
-          maxWidth: 700,
-          margin: '2rem auto',
-          padding: '1.5rem',
-          fontFamily: 'Arial, sans-serif',
-          textAlign: 'center',
-        }}
-      >
-        {defaultHead}
+      <>
         <NavBar />
-        <p style={{ marginTop: '2rem' }}>No data available.</p>
-        <p>Please check back later.</p>
-      </div>
+        <div
+          style={{
+            maxWidth: 700,
+            margin: '2rem auto',
+            padding: '1.5rem',
+            fontFamily: 'Arial, sans-serif',
+            textAlign: 'center',
+          }}
+        >
+          {defaultHead}
+          <p style={{ marginTop: '2rem' }}>No data available.</p>
+          <p>Please check back later.</p>
+        </div>
+      </>
     );
   }
 
@@ -87,27 +89,29 @@ export default function TeamPage({ data, team }) {
   if (!teamExists) {
     // 🚫 No ads here, just a message
     return (
-      <div
-        style={{
-          maxWidth: 700,
-          margin: '2rem auto',
-          padding: '1.5rem',
-          fontFamily: 'Arial, sans-serif',
-          backgroundColor: '#fff',
-          borderRadius: '8px',
-          boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
-          textAlign: 'center',
-        }}
-      >
-        {defaultHead}
+      <>
         <NavBar />
-        <h1 style={{ fontSize: '2rem', color: '#001f3f', marginTop: '1rem' }}>
-          Team not found
-        </h1>
-        <p style={{ fontSize: '1.1rem', marginTop: '1rem' }}>
-          The team <strong>{team}</strong> is not in the College Football Belt history.
-        </p>
-      </div>
+        <div
+          style={{
+            maxWidth: 700,
+            margin: '2rem auto',
+            padding: '1.5rem',
+            fontFamily: 'Arial, sans-serif',
+            backgroundColor: '#fff',
+            borderRadius: '8px',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
+            textAlign: 'center',
+          }}
+        >
+          {defaultHead}
+          <h1 style={{ fontSize: '2rem', color: '#001f3f', marginTop: '1rem' }}>
+            Team not found
+          </h1>
+          <p style={{ fontSize: '1.1rem', marginTop: '1rem' }}>
+            The team <strong>{team}</strong> is not in the College Football Belt history.
+          </p>
+        </div>
+      </>
     );
   }
 
@@ -198,36 +202,37 @@ export default function TeamPage({ data, team }) {
   };
 
   return (
-    <div
-      style={{
-        maxWidth: 900,
-        margin: '2rem auto',
-        padding: '1.5rem',
-        fontFamily: 'Arial, sans-serif',
-        color: '#111',
-        backgroundColor: '#fff',
-        boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
-        borderRadius: '8px',
-      }}
-    >
-      {head}
+    <>
       <NavBar />
+      <div
+        style={{
+          maxWidth: 900,
+          margin: '2rem auto',
+          padding: '1.5rem',
+          fontFamily: 'Arial, sans-serif',
+          color: '#111',
+          backgroundColor: '#fff',
+          boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
+          borderRadius: '8px',
+        }}
+      >
+        {head}
 
-      {/* ✅ Gate manual ads on real data */}
-      <div style={{ marginBottom: '1.5rem' }}>
-        <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
-      </div>
+        {/* ✅ Gate manual ads on real data */}
+        <div style={{ marginBottom: '1.5rem' }}>
+          <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
+        </div>
 
-      <div style={{ textAlign: 'center', marginBottom: '1.5rem' }}>
-        {logoUrl && (
-          <img
-            src={logoUrl}
-            alt={`${team} logo`}
-            style={{ height: 100 }}
-          />
-        )}
-        <h1 style={{ fontSize: '2rem', color: '#001f3f' }}>{team}</h1>
-      </div>
+        <div style={{ textAlign: 'center', marginBottom: '1.5rem' }}>
+          {logoUrl && (
+            <img
+              src={logoUrl}
+              alt={`${team} logo`}
+              style={{ height: 100 }}
+            />
+          )}
+          <h1 style={{ fontSize: '2rem', color: '#001f3f' }}>{team}</h1>
+        </div>
 
       <p
         style={{
@@ -347,10 +352,11 @@ export default function TeamPage({ data, team }) {
         </table>
       </div>
 
-      <div style={{ marginBottom: '1.5rem' }}>
-      <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
+        <div style={{ marginBottom: '1.5rem' }}>
+          <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/pages/team/allteamsrecords.js
+++ b/pages/team/allteamsrecords.js
@@ -27,20 +27,22 @@ export default function AllTeamsRecords({ data }) {
 
   if (!data.length) {
     return (
-      <div
-        style={{
-          maxWidth: '700px',
-          margin: '2rem auto',
-          padding: '1rem',
-          fontFamily: 'Arial, sans-serif',
-          textAlign: 'center',
-        }}
-      >
-        {head}
+      <>
         <NavBar />
-        <p style={{ marginTop: '2rem' }}>No data available.</p>
-        <p>Try again later.</p>
-      </div>
+        <div
+          style={{
+            maxWidth: '700px',
+            margin: '2rem auto',
+            padding: '1rem',
+            fontFamily: 'Arial, sans-serif',
+            textAlign: 'center',
+          }}
+        >
+          {head}
+          <p style={{ marginTop: '2rem' }}>No data available.</p>
+          <p>Try again later.</p>
+        </div>
+      </>
     );
   }
 
@@ -78,13 +80,14 @@ export default function AllTeamsRecords({ data }) {
   };
 
   return (
-    <div style={{ maxWidth: '1000px', margin: '0 auto', padding: '1rem' }}>
-      {head}
+    <>
       <NavBar />
+      <div style={{ maxWidth: '1000px', margin: '0 auto', padding: '1rem' }}>
+        {head}
 
-      <div style={{ marginBottom: '1.5rem' }}>
-        <AdSlot AdSlot="9168138847" variant="leaderboard" enabled={data.length > 0} />
-      </div>
+        <div style={{ marginBottom: '1.5rem' }}>
+          <AdSlot AdSlot="9168138847" variant="leaderboard" enabled={data.length > 0} />
+        </div>
 
       <h1 style={{ textAlign: 'center', fontSize: '1.5rem', fontWeight: 'bold' }}>All Teams Records</h1>
       <h2 style={{ textAlign: 'center', fontSize: '1.25rem', margin: '0.5rem 0', color: '#001f3f' }}>About These Team Records</h2>
@@ -142,11 +145,11 @@ export default function AllTeamsRecords({ data }) {
         );
       })}
 
-      <div style={{ margin: '1.5rem 0' }}>
-        <AdSlot AdSlot="9168138847" variant="leaderboard" enabled={data.length > 0} />
-      </div>
+        <div style={{ margin: '1.5rem 0' }}>
+          <AdSlot AdSlot="9168138847" variant="leaderboard" enabled={data.length > 0} />
+        </div>
 
-      <style jsx>{`
+        <style jsx>{`
         .rowLink { text-decoration: none; color: inherit; }
         .gridRow {
           display: grid;
@@ -187,7 +190,8 @@ export default function AllTeamsRecords({ data }) {
           .gridRow > :nth-child(8) { display: none; }
         }
       `}</style>
-    </div>
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- Render navigation bar above page containers so it spans the full viewport on every page
- Add bottom margin and prevent link text wrapping in the navigation bar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68c493be1da083329120264a1a1ce915