### PR TITLE
Fix navbar overflow on mobile

### DIFF
--- a/components/NavBar.module.css
+++ b/components/NavBar.module.css
@@ -9,7 +9,8 @@
 .container {
   display: flex;
   align-items: center;
-  height: 56px; /* h-14 */
+  flex-wrap: wrap;
+  min-height: 56px; /* h-14 */
   padding: 0 1rem; /* px-4 */
 }
 
@@ -31,6 +32,7 @@
   gap: 1.5rem; /* gap-6 */
   margin-left: 2rem; /* ml-8 */
   padding-left: 0;
+  flex-wrap: wrap;
 }
 
 .link {
@@ -48,6 +50,25 @@
 .link:hover {
   background-color: #1f2937; /* gray-800 */
   color: #fff;
+}
+
+@media (max-width: 640px) {
+  .container {
+    flex-direction: column;
+    align-items: flex-start;
+    min-height: 0;
+  }
+
+  .links {
+    width: 100%;
+    margin-left: 0;
+    gap: 0.5rem;
+  }
+
+  .link {
+    font-size: 0.8125rem;
+    padding: 0.5rem 0;
+  }
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
## Summary
- allow navigation container and links to wrap
- add mobile breakpoint to stack links and shrink font

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c591372c688332ae92f5545e1c595d