### PR TITLE
Update belt after Miami routs USF

### DIFF
--- a/data/belt-history.csv
+++ b/data/belt-history.csv
@@ -1,5 +1,6 @@
 Overall Reign #,BeltHolder,TeamReign,StartofReign,EndofReign,# of Defenses,BeltWon,Defense 1,Defense 2,Defense 3,Defense 4,Defense 5,Defense 6,Defense 7,Defense 8,Defense 9,Defense 10,Defense 11,Defense 12,Defense 13,Defense 14,Defense 15,Defense 16,Defense 17,Defense 18,Defense 19,Defense 20,Defense 21,Defense 22,Defense 23,Defense 24,Defense 25,Defense 26,Defense 27,Defense 28,Defense 29,Defense 30,Defense 31,Defense 32,Defense 33,Defense 34,Defense 35,Defense 36,Defense 37
-331,South Florida,1,09/06/2025,Ongoing,0,at Florida (W 18–16),at Miami,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+332,Miami,6,09/13/2025,Ongoing,0,vs. South Florida (W 49–12),vs. Florida,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+331,South Florida,1,09/06/2025,09/13/2025,0,at Florida (W 18–16),at Miami (L 49–12),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 330,Florida,6,11/23/2024,09/06/2025,3,vs. #9 Ole Miss (W 24–14),at Florida State (W 31–11),vs. Tulane (Gasparilla Bowl) (W 33–8),vs. LIU (W 55-0),vs. South Florida (L 18-16),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 329,Ole Miss,6,11/10/2024,11/23/2024,0,vs. Georgia (W 28–10),at Florida (L 24–14),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 328,Georgia,6,10/19/2024,11/10/2024,1,at Texas (W 30–15),vs. Florida (neutral site) (W 34–20),at Ole Miss (L 28–10),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,

--- a/pages/index.js
+++ b/pages/index.js
@@ -192,7 +192,7 @@ export default function HomePage({ data }) {
       <section className="mb-8">
         <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>Next Game Preview</h2>
         <p className="text-gray-900 leading-relaxed">
-          Miami seized the College Football Belt with a commanding 49–12 home win over South Florida. The Hurricanes now prepare for their first defense as they host the Florida Gators in a heated in-state clash.
+          Miami seized the College Football Belt with a commanding 49–12 home win over South Florida. The Hurricanes now prepare for their first defense as they host the Florida Gators in a heated in-state clash. Florida entered the season with the belt, lost it to USF, and already has a chance to win it back one week later. 
         </p>
       </section>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -28,7 +28,7 @@ export default function HomePage({ data }) {
   const router = useRouter();
   const page = parseInt(router.query.page || '1', 10);
   const itemsPerPage = 10;
-  const nextOpponent = 'Miami';
+  const nextOpponent = 'Florida';
 
   if (!data.length) {
     return (
@@ -192,9 +192,7 @@ export default function HomePage({ data }) {
       <section className="mb-8">
         <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>Next Game Preview</h2>
         <p className="text-gray-900 leading-relaxed">
-          South Florida begins its first ever belt reign with a showdown against the Miami Hurricanes. The Bulls seek their first
-          defense and aim to extend the surprising College Football Belt reign. Miami was expected to potentially have a shot at
-          the belt against an in-state team preseason, but it was not expected to be USF.
+          Miami seized the College Football Belt with a commanding 49–12 home win over South Florida. The Hurricanes now prepare for their first defense as they host the Florida Gators in a heated in-state clash.
         </p>
       </section>
 


### PR DESCRIPTION
## Summary
- Record Miami's 49-12 win over South Florida and new belt reign
- Preview upcoming belt defense vs Florida

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(could not run: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c813a03e248332a2ae7c89a9c4e1f3