### PR TITLE
feat: load amazon ads from API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ NEXT_PUBLIC_ADSENSE_ENABLED="true" # use AdSense; any other value shows the Amaz
 
 Enable this flag only after your AdSense account and the site have been approved. Once the flag is set to `"true"`, the AdSense script is injected dynamically and `<AdSlot>` components will render AdSense `<ins class="adsbygoogle">` slots. When the flag is not `"true"`, `<AdSlot>` instead renders the Amazon affiliate banner.
 
+### Amazon Product Advertising API
+
+The Amazon banner uses the Product Advertising API to fetch product details. Provide the following credentials in your environment for the `/api/amazon-ads` endpoint:
+
+```
+AMAZON_ACCESS_KEY="your_access_key"
+AMAZON_SECRET_KEY="your_secret_key"
+AMAZON_ASSOCIATE_TAG="yourtag-20"
+```
+
+`components/AmazonBanner.js` displays up to three products for the query `college football gear` and falls back to static SVG panels when the API request fails.
+
 ## Newsletter signup
 
 The site includes an email newsletter powered by [Mailchimp](https://mailchimp.com). To enable the signup form, set the following environment variables:

--- a/components/AmazonBanner.js
+++ b/components/AmazonBanner.js
@@ -1,93 +1,133 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 /**
- * Simple Amazon affiliate banner composed of three ad panels.
- * Replace the SVG graphics with real images when available.
+ * Renders Amazon affiliate ads using the Product Advertising API.
+ * Falls back to static SVG panels when the API is unavailable.
  */
 export default function AmazonBanner() {
+  const [items, setItems] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(
+          "/api/amazon-ads?keywords=college%20football%20gear"
+        );
+        if (res.ok) {
+          const data = await res.json();
+          setItems(data.items);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, []);
+
+  if (!items || items.length === 0) {
+    return (
+      <div className="flex flex-wrap justify-center gap-2 mt-8 mb-4">
+        <a
+          href="https://amzn.to/4gmUa7I"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block"
+        >
+          <svg
+            width="300"
+            height="100"
+            xmlns="http://www.w3.org/2000/svg"
+            className="block max-w-full"
+          >
+            <rect width="300" height="100" fill="#006747" />
+            <text
+              x="50%"
+              y="50%"
+              dominantBaseline="middle"
+              textAnchor="middle"
+              fontFamily="Arial"
+              fontSize="20"
+              fill="#ffffff"
+            >
+              USF Bulls Gear
+            </text>
+          </svg>
+        </a>
+
+        <a
+          href="https://amzn.to/4nrJHu1"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block"
+        >
+          <svg
+            width="300"
+            height="100"
+            xmlns="http://www.w3.org/2000/svg"
+            className="block max-w-full"
+          >
+            <rect width="300" height="100" fill="#c0a16b" />
+            <text
+              x="50%"
+              y="50%"
+              dominantBaseline="middle"
+              textAnchor="middle"
+              fontFamily="Arial"
+              fontSize="20"
+              fill="#000000"
+            >
+              Fantasy Football Belts
+            </text>
+          </svg>
+        </a>
+
+        <a
+          href="https://amzn.to/4nrJHu1"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block"
+        >
+          <svg
+            width="300"
+            height="100"
+            xmlns="http://www.w3.org/2000/svg"
+            className="block max-w-full"
+          >
+            <rect width="300" height="100" fill="#f47321" />
+            <text
+              x="50%"
+              y="50%"
+              dominantBaseline="middle"
+              textAnchor="middle"
+              fontFamily="Arial"
+              fontSize="20"
+              fill="#ffffff"
+            >
+              Miami Hurricanes Gear
+            </text>
+          </svg>
+        </a>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-wrap justify-center gap-2 mt-8 mb-4">
-      <a
-        href="https://amzn.to/4gmUa7I"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block"
-      >
-        <svg
-          width="300"
-          height="100"
-          xmlns="http://www.w3.org/2000/svg"
-          className="block max-w-full"
+      {items.map((item) => (
+        <a
+          key={item.asin}
+          href={item.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block"
         >
-          <rect width="300" height="100" fill="#006747" />
-          <text
-            x="50%"
-            y="50%"
-            dominantBaseline="middle"
-            textAnchor="middle"
-            fontFamily="Arial"
-            fontSize="20"
-            fill="#ffffff"
-          >
-            USF Bulls Gear
-          </text>
-        </svg>
-      </a>
-
-      <a
-        href="https://amzn.to/4nrJHu1"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block"
-      >
-        <svg
-          width="300"
-          height="100"
-          xmlns="http://www.w3.org/2000/svg"
-          className="block max-w-full"
-        >
-          <rect width="300" height="100" fill="#c0a16b" />
-          <text
-            x="50%"
-            y="50%"
-            dominantBaseline="middle"
-            textAnchor="middle"
-            fontFamily="Arial"
-            fontSize="20"
-            fill="#000000"
-          >
-            Fantasy Football Belts
-          </text>
-        </svg>
-      </a>
-
-      <a
-        href="https://amzn.to/4nrJHu1"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block"
-      >
-        <svg
-          width="300"
-          height="100"
-          xmlns="http://www.w3.org/2000/svg"
-          className="block max-w-full"
-        >
-          <rect width="300" height="100" fill="#f47321" />
-          <text
-            x="50%"
-            y="50%"
-            dominantBaseline="middle"
-            textAnchor="middle"
-            fontFamily="Arial"
-            fontSize="20"
-            fill="#ffffff"
-          >
-            Miami Hurricanes Gear
-          </text>
-        </svg>
-      </a>
+          <img
+            src={item.image}
+            alt={item.title}
+            className="block max-w-full w-72 h-24 object-cover"
+          />
+        </a>
+      ))}
     </div>
   );
 }
-

--- a/pages/api/amazon-ads.js
+++ b/pages/api/amazon-ads.js
@@ -1,0 +1,18 @@
+import { searchItems } from "../../utils/amazon.js";
+
+export default async function handler(req, res) {
+  const { keywords = "college football gear" } = req.query;
+  try {
+    const data = await searchItems(keywords);
+    const items = (data.SearchResult?.Items || []).slice(0, 3).map((item) => ({
+      asin: item.ASIN,
+      title: item.ItemInfo?.Title?.DisplayValue,
+      image: item.Images?.Primary?.Large?.URL,
+      link: item.DetailPageURL,
+    }));
+    res.status(200).json({ items });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Failed to fetch Amazon products" });
+  }
+}


### PR DESCRIPTION
## Summary
- fetch Amazon products via Product Advertising API
- render dynamic banner with fallback to static affiliate SVGs
- document Amazon API credentials

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c81b507cc88332b638b41225fa440c