### PR TITLE
Improve Amazon API error reporting

### DIFF
--- a/pages/api/amazon-ads.js
+++ b/pages/api/amazon-ads.js
@@ -12,7 +12,9 @@ export default async function handler(req, res) {
     }));
     res.status(200).json({ items });
   } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: "Failed to fetch Amazon products" });
+    const message =
+      err instanceof Error ? err.message : "Failed to fetch Amazon products";
+    console.error("Amazon ads API error:", err);
+    res.status(500).json({ error: message });
   }
 }

--- a/utils/amazon.js
+++ b/utils/amazon.js
@@ -92,7 +92,19 @@ export async function searchItems(keywords) {
     body: payload,
   });
   if (!response.ok) {
-    throw new Error(`Amazon API error: ${response.status}`);
+    let errorMessage = response.statusText;
+    try {
+      const errorText = await response.text();
+      if (errorText) {
+        errorMessage = `${errorMessage ? `${errorMessage} - ` : ""}${errorText}`;
+      }
+    } catch (readError) {
+      // If reading the error body fails, fall back to the status text.
+      errorMessage = errorMessage || "Unable to read error body";
+    }
+    throw new Error(`Amazon API error: ${response.status}${
+      errorMessage ? ` ${errorMessage}` : ""
+    }`);
   }
   return response.json();
 }


### PR DESCRIPTION
## Summary
- include Amazon error response text when searchItems fails
- return the detailed Amazon error message from the amazon-ads API handler

## Testing
- not run (Next.js lint command prompts for configuration interactively)


------
https://chatgpt.com/codex/tasks/task_e_68c87dcf2348833298e0c43de8fa50fa