### PR TITLE
Configure Amazon banner to fetch specific ASINs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ The Amazon banner uses the Product Advertising API to fetch product details. Pro
 AMAZON_ACCESS_KEY="your_access_key"
 AMAZON_SECRET_KEY="your_secret_key"
 AMAZON_ASSOCIATE_TAG="yourtag-20"
+AMAZON_ASINS="B0D8KTKMQW,B00W5VNB80,B07QYCVT29,XXXXXXXXXX"
 ```
 
-`components/AmazonBanner.js` displays up to three products for the query `college football gear` and falls back to static SVG panels when the API request fails.
+Set `AMAZON_ASINS` to a comma-separated list of ASINs you want to feature. The example above uses the ASINs for the Florida Gators wall art, Miami Hurricanes necklace, and fantasy football belt links that ship with this project—replace `XXXXXXXXXX` with the ASIN behind your shortened URL. The banner calls Amazon's `GetItems` endpoint to retrieve the latest product title, hero image, and price for each ASIN so the creative stays compliant with Amazon's 24-hour pricing freshness requirement. If the API request fails or no ASINs are configured, the banner falls back to static SVG panels.
 
 ## Newsletter signup
 

--- a/components/AmazonBanner.js
+++ b/components/AmazonBanner.js
@@ -6,13 +6,37 @@ import React, { useEffect, useState } from "react";
  */
 export default function AmazonBanner() {
   const [items, setItems] = useState(null);
+  const fallbackProducts = [
+    {
+      href: "https://www.amazon.com/PILOYINDE-Basketball-gators-Bedroom-Florida/dp/B0D8KTKMQW?crid=AHXD6SCISDXA&dib=eyJ2IjoiMSJ9.pk6LKRJrWyC7tifXE2tQbN2UHnVHAwrlI4IPwD53yX2X4rStgfTuv1E_gHFBJRWrYYNyzek8UgroFTHJ2qfBC9oFmhWiy6wCjPYdM_XIc9ixmGdf9mpDyNYY6kFC2lvq9Q-RouPS3N-7afPhlf5A8xbgqwmjs6dGSCNuwfl6LoHCn4NcQk-KFNeveGhubv6-mgtvtFedK9ZOKUEb78pPxg-PyAS1yWzmtKb2Cgn0K0PxHLRP3ELlvTId2RxRFpUWmn2XddGhIf56XIk9eMrKX-Nzb6rvOrDJpD8Tt9d6Ncw.c6dWX31Ia5o_cu0xK9xQRP160sau0_kFYXJ94CuoEl4&dib_tag=se&keywords=florida%2Bgators%2Bgear&qid=1758030266&sprefix=florida%2Bgators%2Bgrea%2Caps%2C196&sr=8-2-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&th=1&linkCode=ll1&tag=cfbbelt-20&linkId=038c37e92c6cfc6ad877d0ab0bbdf5d0&language=en_US&ref_=as_li_ss_tl",
+      label: "Florida Gators Wall Art",
+      fill: "#0021A5",
+      textColor: "#ffffff",
+    },
+    {
+      href: "https://www.amazon.com/Siskiyou-Miami-Hurricanes-Necklace-Pendant/dp/B00W5VNB80?crid=2JFJ68NWBB0NX&dib=eyJ2IjoiMSJ9.8JZNSm2ose3w2zaLqSd3PBZhCJ-vKRa68bFQC3LPRjgyVZ1NXG-QHYgY8kWt1ATtbrGSzEaY9IuZgACKQMgCy0La7mQzsa9ePeLeJm_YJ3S19do2X48i5kgFKqabrgPsWFjtv7XfN649imR0HHbahJWZLMi_kIaq-vr9papqFqiQZEQVP0dCljv6GgCHPehr5_9ufKPHbB-gzzq_3VOS9yDq44haNznBuNq8TRCYTK61npO2iEG_cQRDsS6HiwKf.0oqJ84BnenLzEa1sL8JwWJfu10NveksJa9PeMblZyRc&dib_tag=se&keywords=umiami%2Bgear&qid=1758030358&sprefix=umiami%2Bgear%2Caps%2C134&sr=8-8&th=1&linkCode=ll1&tag=cfbbelt-20&linkId=d5d97882d4d124be5d5f50200f486d04&language=en_US&ref_=as_li_ss_tl",
+      label: "Miami Hurricanes Necklace",
+      fill: "#F47321",
+      textColor: "#ffffff",
+    },
+    {
+      href: "https://www.amazon.com/Fantasy-Football-Championship-Belt-Customizable/dp/B07QYCVT29?crid=Q7YY7RE6H763&dib=eyJ2IjoiMSJ9.kwrLnnk6Djg0nFGBOv06n0Po5_hZjoaR-8Y3eBKS7At15wfR7JVGcdnuA6wg0jRDuePBB0gd9Dq77v8rHb5UDF2qnY3U6rcPLJLDg27HDzgPVC9Uq_4yIDLX_YALbnAdPF9Tstf-XS2QrqQyZQa63iY4x8rPVXA2tSdvlzYTLsZBye6JsR_aWH7q3HVWWqlhzP7ZlqDvzxXAe4OccreHLGt_eurivWY6pZB8MYscCOJMjAwgWG5GzBBtWwCdu79pBkcsOfvSbo8NRGxdjvDk8GqCtxQpxS3jLelakOPrgAs.FzhlfvbA3ygxTp0pooYXuj378S2he05Y6CjQoZgls-I&dib_tag=se&keywords=fantasy%2Bfootball%2Bbelt&qid=1758030444&sprefix=fantasy%2Bfootball%2Bbelt%2Caps%2C136&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&th=1&linkCode=ll1&tag=cfbbelt-20&linkId=6fab320414a8b06b3008c4b4df84b9a9&language=en_US&ref_=as_li_ss_tl",
+      label: "Fantasy Football Championship Belt",
+      fill: "#C0A16B",
+      textColor: "#000000",
+    },
+    {
+      href: "https://amzn.to/3IaxStf",
+      label: "Featured Amazon Pick",
+      fill: "#006747",
+      textColor: "#ffffff",
+    },
+  ];
 
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch(
-          "/api/amazon-ads?keywords=college%20football%20gear"
-        );
+        const res = await fetch("/api/amazon-ads");
         if (res.ok) {
           const data = await res.json();
           setItems(data.items);
@@ -27,105 +51,69 @@ export default function AmazonBanner() {
   if (!items || items.length === 0) {
     return (
       <div className="flex flex-wrap justify-center gap-2 mt-8 mb-4">
-        <a
-          href="https://amzn.to/4gmUa7I"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block"
-        >
-          <svg
-            width="300"
-            height="100"
-            xmlns="http://www.w3.org/2000/svg"
-            className="block max-w-full"
+        {fallbackProducts.map((product) => (
+          <a
+            key={product.href}
+            href={product.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block"
           >
-            <rect width="300" height="100" fill="#006747" />
-            <text
-              x="50%"
-              y="50%"
-              dominantBaseline="middle"
-              textAnchor="middle"
-              fontFamily="Arial"
-              fontSize="20"
-              fill="#ffffff"
+            <svg
+              width="300"
+              height="100"
+              xmlns="http://www.w3.org/2000/svg"
+              className="block max-w-full"
             >
-              USF Bulls Gear
-            </text>
-          </svg>
-        </a>
-
-        <a
-          href="https://amzn.to/4nrJHu1"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block"
-        >
-          <svg
-            width="300"
-            height="100"
-            xmlns="http://www.w3.org/2000/svg"
-            className="block max-w-full"
-          >
-            <rect width="300" height="100" fill="#c0a16b" />
-            <text
-              x="50%"
-              y="50%"
-              dominantBaseline="middle"
-              textAnchor="middle"
-              fontFamily="Arial"
-              fontSize="20"
-              fill="#000000"
-            >
-              Fantasy Football Belts
-            </text>
-          </svg>
-        </a>
-
-        <a
-          href="https://amzn.to/4nrJHu1"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block"
-        >
-          <svg
-            width="300"
-            height="100"
-            xmlns="http://www.w3.org/2000/svg"
-            className="block max-w-full"
-          >
-            <rect width="300" height="100" fill="#f47321" />
-            <text
-              x="50%"
-              y="50%"
-              dominantBaseline="middle"
-              textAnchor="middle"
-              fontFamily="Arial"
-              fontSize="20"
-              fill="#ffffff"
-            >
-              Miami Hurricanes Gear
-            </text>
-          </svg>
-        </a>
+              <rect width="300" height="100" fill={product.fill} />
+              <text
+                x="50%"
+                y="50%"
+                dominantBaseline="middle"
+                textAnchor="middle"
+                fontFamily="Arial"
+                fontSize="18"
+                fill={product.textColor}
+              >
+                {product.label}
+              </text>
+            </svg>
+          </a>
+        ))}
       </div>
     );
   }
 
   return (
-    <div className="flex flex-wrap justify-center gap-2 mt-8 mb-4">
+    <div className="flex flex-wrap justify-center gap-4 mt-8 mb-4">
       {items.map((item) => (
         <a
           key={item.asin}
           href={item.link}
           target="_blank"
           rel="noopener noreferrer"
-          className="block"
+          className="block w-72 transition-shadow hover:shadow-md"
         >
-          <img
-            src={item.image}
-            alt={item.title}
-            className="block max-w-full w-72 h-24 object-cover"
-          />
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            {item.image && (
+              <img
+                src={item.image}
+                alt={item.title}
+                loading="lazy"
+                className="block h-36 w-full object-cover"
+              />
+            )}
+            <div className="p-3">
+              <p className="text-sm font-semibold text-gray-900 leading-snug">
+                {item.title}
+              </p>
+              {item.price && (
+                <p className="mt-2 text-sm font-bold text-emerald-700">
+                  {item.price}
+                </p>
+              )}
+            </div>
+          </div>
         </a>
       ))}
     </div>

--- a/pages/api/amazon-ads.js
+++ b/pages/api/amazon-ads.js
@@ -1,15 +1,100 @@
-import { searchItems } from "../../utils/amazon.js";
+import { getItems, searchItems } from "../../utils/amazon.js";
+
+function parseAsins(value) {
+  if (!value) {
+    return [];
+  }
+  const rawValues = Array.isArray(value) ? value : [value];
+  return rawValues
+    .flatMap((entry) =>
+      typeof entry === "string" ? entry.split(/[\s,]+/) : []
+    )
+    .map((asin) => asin.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+function formatPrice(listing, summary) {
+  const display =
+    listing?.Price?.DisplayAmount || summary?.LowestPrice?.DisplayAmount;
+  if (display) {
+    return display;
+  }
+  const amount =
+    listing?.Price?.Amount ?? summary?.LowestPrice?.Amount ?? undefined;
+  const currency =
+    listing?.Price?.Currency ?? summary?.LowestPrice?.Currency ?? undefined;
+  if (typeof amount === "number" && currency) {
+    try {
+      return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency,
+      }).format(amount);
+    } catch (err) {
+      return `${currency} ${amount.toFixed(2)}`;
+    }
+  }
+  return undefined;
+}
+
+function mapAmazonItem(item) {
+  const listing = item?.Offers?.Listings?.[0];
+  const summary = item?.Offers?.Summaries?.[0];
+  return {
+    asin: item?.ASIN?.toUpperCase(),
+    title: item?.ItemInfo?.Title?.DisplayValue,
+    image:
+      item?.Images?.Primary?.Large?.URL ||
+      item?.Images?.Primary?.Medium?.URL ||
+      item?.Images?.Primary?.Small?.URL,
+    link: item?.DetailPageURL,
+    price: formatPrice(listing, summary),
+  };
+}
 
 export default async function handler(req, res) {
-  const { keywords = "college football gear" } = req.query;
+  const { keywords } = req.query;
+  let asinList = parseAsins(req.query.asins);
+  if (asinList.length === 0) {
+    asinList = parseAsins(process.env.AMAZON_ASINS || "");
+  }
   try {
-    const data = await searchItems(keywords);
-    const items = (data.SearchResult?.Items || []).slice(0, 3).map((item) => ({
-      asin: item.ASIN,
-      title: item.ItemInfo?.Title?.DisplayValue,
-      image: item.Images?.Primary?.Large?.URL,
-      link: item.DetailPageURL,
-    }));
+    let items = [];
+    if (asinList.length > 0) {
+      const data = await getItems(asinList);
+      if (Array.isArray(data?.Errors) && data.Errors.length > 0) {
+        const errorMessage = data.Errors.map((error) => error.Message || error.Code)
+          .filter(Boolean)
+          .join("; ");
+        throw new Error(errorMessage || "Amazon GetItems response contained errors");
+      }
+      const mapped = new Map(
+        (data.ItemsResult?.Items || []).map((item) => [
+          item?.ASIN?.toUpperCase(),
+          mapAmazonItem(item),
+        ])
+      );
+      items = asinList
+        .map((asin) => mapped.get(asin))
+        .filter(
+          (item) => item && item.image && item.link && item.title
+        );
+    } else {
+      const fallbackKeywords =
+        typeof keywords === "string" && keywords.trim().length > 0
+          ? keywords
+          : "college football gear";
+      const data = await searchItems(fallbackKeywords);
+      if (Array.isArray(data?.Errors) && data.Errors.length > 0) {
+        const errorMessage = data.Errors.map((error) => error.Message || error.Code)
+          .filter(Boolean)
+          .join("; ");
+        throw new Error(errorMessage || "Amazon SearchItems response contained errors");
+      }
+      items = (data.SearchResult?.Items || [])
+        .map(mapAmazonItem)
+        .filter((item) => item.image && item.link && item.title)
+        .slice(0, 3);
+    }
     res.status(200).json({ items });
   } catch (err) {
     const message =


### PR DESCRIPTION
## Summary
- switch the Amazon banner to call the Product Advertising API GetItems endpoint for a configurable ASIN list
- display the returned title, hero image, and price for each featured item and update the static fallback creatives
- document the new AMAZON_ASINS environment variable and reuse shared signing logic for both SearchItems and GetItems requests

## Testing
- npm run lint *(fails: command prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68c96ab26b84833296bc541e4c3bb43f