### PR TITLE
Configure Amazon banner to fetch specific ASINs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ The Amazon banner uses the Product Advertising API to fetch product details. Pro
 AMAZON_ACCESS_KEY="your_access_key"
 AMAZON_SECRET_KEY="your_secret_key"
 AMAZON_ASSOCIATE_TAG="yourtag-20"
+AMAZON_ASINS="B0D8KTKMQW,B00W5VNB80,B07QYCVT29,XXXXXXXXXX"
 ```
 
-`components/AmazonBanner.js` displays up to three products for the query `college football gear` and falls back to static SVG panels when the API request fails.
+Set `AMAZON_ASINS` to a comma-separated list (up to six entries) of ASINs you want to feature for the current week's Belt matchup. The example above uses the ASINs for the Florida Gators wall art, Miami Hurricanes necklace, and fantasy football belt links that ship with this project—replace `XXXXXXXXXX` with the ASIN behind your shortened URL. The banner calls Amazon's `GetItems` endpoint to retrieve the latest product title, hero image, and price for each ASIN so the creative stays compliant with Amazon's 24-hour pricing freshness requirement. If the API request fails or no ASINs are configured, the banner now simply displays a reminder to check back later instead of rendering stale fallback products.
 
 ## Newsletter signup
 

--- a/components/AmazonBanner.js
+++ b/components/AmazonBanner.js
@@ -1,132 +1,100 @@
 import React, { useEffect, useState } from "react";
 
+const MAX_PRODUCTS = 6;
+
+function ProductCard({ href, image, price, title }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block w-72 transition-shadow hover:shadow-lg"
+    >
+      <div className="flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        {image ? (
+          <img
+            src={image}
+            alt={title}
+            loading="lazy"
+            className="block h-40 w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-40 w-full items-center justify-center bg-emerald-50 text-sm font-semibold uppercase text-emerald-700">
+            Amazon Deal
+          </div>
+        )}
+        <div className="flex flex-1 flex-col gap-2 p-4">
+          <p className="text-sm font-semibold leading-snug text-gray-900">{title}</p>
+          <p className="text-sm font-semibold text-emerald-700">
+            {price || "See today's price"}
+          </p>
+          <span className="mt-auto text-sm font-medium text-emerald-600">
+            Shop now on Amazon →
+          </span>
+        </div>
+      </div>
+    </a>
+  );
+}
+
 /**
  * Renders Amazon affiliate ads using the Product Advertising API.
- * Falls back to static SVG panels when the API is unavailable.
+ * Shows a notice when the curated ASIN list cannot be loaded.
  */
 export default function AmazonBanner() {
   const [items, setItems] = useState(null);
 
   useEffect(() => {
+    let cancelled = false;
+
     async function load() {
       try {
-        const res = await fetch(
-          "/api/amazon-ads?keywords=college%20football%20gear"
-        );
-        if (res.ok) {
-          const data = await res.json();
-          setItems(data.items);
+        const res = await fetch("/api/amazon-ads");
+        if (!res.ok) {
+          throw new Error(`Amazon banner request failed with ${res.status}`);
+        }
+        const data = await res.json();
+        if (!cancelled) {
+          const normalized = Array.isArray(data.items) ? data.items : [];
+          setItems(normalized.slice(0, MAX_PRODUCTS));
         }
       } catch (err) {
         console.error(err);
+        if (!cancelled) {
+          setItems([]);
+        }
       }
     }
+
     load();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  if (!items || items.length === 0) {
+  if (items === null) {
+    return null;
+  }
+
+  if (items.length === 0) {
     return (
-      <div className="flex flex-wrap justify-center gap-2 mt-8 mb-4">
-        <a
-          href="https://amzn.to/4gmUa7I"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block"
-        >
-          <svg
-            width="300"
-            height="100"
-            xmlns="http://www.w3.org/2000/svg"
-            className="block max-w-full"
-          >
-            <rect width="300" height="100" fill="#006747" />
-            <text
-              x="50%"
-              y="50%"
-              dominantBaseline="middle"
-              textAnchor="middle"
-              fontFamily="Arial"
-              fontSize="20"
-              fill="#ffffff"
-            >
-              USF Bulls Gear
-            </text>
-          </svg>
-        </a>
-
-        <a
-          href="https://amzn.to/4nrJHu1"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block"
-        >
-          <svg
-            width="300"
-            height="100"
-            xmlns="http://www.w3.org/2000/svg"
-            className="block max-w-full"
-          >
-            <rect width="300" height="100" fill="#c0a16b" />
-            <text
-              x="50%"
-              y="50%"
-              dominantBaseline="middle"
-              textAnchor="middle"
-              fontFamily="Arial"
-              fontSize="20"
-              fill="#000000"
-            >
-              Fantasy Football Belts
-            </text>
-          </svg>
-        </a>
-
-        <a
-          href="https://amzn.to/4nrJHu1"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block"
-        >
-          <svg
-            width="300"
-            height="100"
-            xmlns="http://www.w3.org/2000/svg"
-            className="block max-w-full"
-          >
-            <rect width="300" height="100" fill="#f47321" />
-            <text
-              x="50%"
-              y="50%"
-              dominantBaseline="middle"
-              textAnchor="middle"
-              fontFamily="Arial"
-              fontSize="20"
-              fill="#ffffff"
-            >
-              Miami Hurricanes Gear
-            </text>
-          </svg>
-        </a>
+      <div className="mt-8 mb-4 text-center text-sm text-gray-600">
+        Check back soon for this week's Belt matchup picks.
       </div>
     );
   }
 
   return (
-    <div className="flex flex-wrap justify-center gap-2 mt-8 mb-4">
+    <div className="mt-8 mb-4 flex flex-wrap justify-center gap-4">
       {items.map((item) => (
-        <a
-          key={item.asin}
+        <ProductCard
+          key={item.asin || item.link}
           href={item.link}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block"
-        >
-          <img
-            src={item.image}
-            alt={item.title}
-            className="block max-w-full w-72 h-24 object-cover"
-          />
-        </a>
+          image={item.image}
+          price={item.price}
+          title={item.title}
+        />
       ))}
     </div>
   );

--- a/pages/api/amazon-ads.js
+++ b/pages/api/amazon-ads.js
@@ -1,15 +1,99 @@
-import { searchItems } from "../../utils/amazon.js";
+import { getItems } from "../../utils/amazon.js";
+
+const MAX_ITEMS = 6;
+
+function parseAsins(value) {
+  if (!value) {
+    return [];
+  }
+  const rawValues = Array.isArray(value) ? value : [value];
+  const seen = new Set();
+  const parsed = [];
+  for (const entry of rawValues) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    for (const candidate of entry.split(/[\s,]+/)) {
+      const asin = candidate.trim().toUpperCase();
+      if (!asin || seen.has(asin)) {
+        continue;
+      }
+      seen.add(asin);
+      parsed.push(asin);
+      if (parsed.length === MAX_ITEMS) {
+        return parsed;
+      }
+    }
+  }
+  return parsed;
+}
+
+function formatPrice(listing, summary) {
+  const display =
+    listing?.Price?.DisplayAmount || summary?.LowestPrice?.DisplayAmount;
+  if (display) {
+    return display;
+  }
+  const amount =
+    listing?.Price?.Amount ?? summary?.LowestPrice?.Amount ?? undefined;
+  const currency =
+    listing?.Price?.Currency ?? summary?.LowestPrice?.Currency ?? undefined;
+  if (typeof amount === "number" && currency) {
+    try {
+      return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency,
+      }).format(amount);
+    } catch (err) {
+      return `${currency} ${amount.toFixed(2)}`;
+    }
+  }
+  return undefined;
+}
+
+function mapAmazonItem(item) {
+  const listing = item?.Offers?.Listings?.[0];
+  const summary = item?.Offers?.Summaries?.[0];
+  return {
+    asin: item?.ASIN?.toUpperCase(),
+    title: item?.ItemInfo?.Title?.DisplayValue,
+    image:
+      item?.Images?.Primary?.Large?.URL ||
+      item?.Images?.Primary?.Medium?.URL ||
+      item?.Images?.Primary?.Small?.URL,
+    link: item?.DetailPageURL,
+    price: formatPrice(listing, summary),
+  };
+}
 
 export default async function handler(req, res) {
-  const { keywords = "college football gear" } = req.query;
+  let asinList = parseAsins(req.query.asins);
+  if (asinList.length === 0) {
+    asinList = parseAsins(process.env.AMAZON_ASINS || "");
+  }
   try {
-    const data = await searchItems(keywords);
-    const items = (data.SearchResult?.Items || []).slice(0, 3).map((item) => ({
-      asin: item.ASIN,
-      title: item.ItemInfo?.Title?.DisplayValue,
-      image: item.Images?.Primary?.Large?.URL,
-      link: item.DetailPageURL,
-    }));
+    if (asinList.length === 0) {
+      res.status(200).json({ items: [] });
+      return;
+    }
+
+    const data = await getItems(asinList);
+    if (Array.isArray(data?.Errors) && data.Errors.length > 0) {
+      const errorMessage = data.Errors.map((error) => error.Message || error.Code)
+        .filter(Boolean)
+        .join("; ");
+      throw new Error(errorMessage || "Amazon GetItems response contained errors");
+    }
+    const mapped = new Map(
+      (data.ItemsResult?.Items || []).map((item) => [
+        item?.ASIN?.toUpperCase(),
+        mapAmazonItem(item),
+      ])
+    );
+    const items = asinList
+      .map((asin) => mapped.get(asin))
+      .filter((item) => item && item.image && item.link && item.title);
+
     res.status(200).json({ items });
   } catch (err) {
     const message =

--- a/utils/amazon.js
+++ b/utils/amazon.js
@@ -3,9 +3,8 @@ import crypto from "crypto";
 const host = "webservices.amazon.com";
 const region = "us-east-1";
 const service = "ProductAdvertisingAPI";
-const endpoint = "/paapi5/searchitems";
 
-function sign(payload, accessKey, secretKey) {
+function sign(payload, accessKey, secretKey, endpoint, target) {
   const amzDate = new Date().toISOString().replace(/[-:]|\..*/g, "") + "Z";
   const dateStamp = amzDate.slice(0, 8);
   const canonicalHeaders =
@@ -13,7 +12,7 @@ function sign(payload, accessKey, secretKey) {
     "content-type:application/json; charset=UTF-8\n" +
     `host:${host}\n` +
     `x-amz-date:${amzDate}\n` +
-    "x-amz-target:com.amazon.paapi5.v1.ProductAdvertisingAPIv1.SearchItems\n";
+    `x-amz-target:${target}\n`;
   const signedHeaders =
     "content-encoding;content-type;host;x-amz-date;x-amz-target";
   const payloadHash = crypto
@@ -58,26 +57,25 @@ function sign(payload, accessKey, secretKey) {
   return { amzDate, authorizationHeader };
 }
 
-export async function searchItems(keywords) {
+function getCredentials() {
   const accessKey = process.env.AMAZON_ACCESS_KEY;
   const secretKey = process.env.AMAZON_SECRET_KEY;
   const associateTag = process.env.AMAZON_ASSOCIATE_TAG;
   if (!accessKey || !secretKey || !associateTag) {
     throw new Error("Missing Amazon API credentials");
   }
-  const payload = JSON.stringify({
-    Keywords: keywords,
-    Marketplace: "www.amazon.com",
-    PartnerTag: associateTag,
-    PartnerType: "Associates",
-    Resources: [
-      "Images.Primary.Large",
-      "ItemInfo.Title",
-      "ItemInfo.ProductInfo",
-      "Offers.Listings.Price",
-    ],
-  });
-  const { amzDate, authorizationHeader } = sign(payload, accessKey, secretKey);
+  return { accessKey, secretKey, associateTag };
+}
+
+async function callAmazon(endpoint, target, payload) {
+  const { accessKey, secretKey } = getCredentials();
+  const { amzDate, authorizationHeader } = sign(
+    payload,
+    accessKey,
+    secretKey,
+    endpoint,
+    target
+  );
   const response = await fetch(`https://${host}${endpoint}`, {
     method: "POST",
     headers: {
@@ -85,8 +83,7 @@ export async function searchItems(keywords) {
       "Content-Type": "application/json; charset=UTF-8",
       Host: host,
       "X-Amz-Date": amzDate,
-      "X-Amz-Target":
-        "com.amazon.paapi5.v1.ProductAdvertisingAPIv1.SearchItems",
+      "X-Amz-Target": target,
       Authorization: authorizationHeader,
     },
     body: payload,
@@ -107,4 +104,29 @@ export async function searchItems(keywords) {
     }`);
   }
   return response.json();
+}
+
+export async function getItems(asins) {
+  if (!Array.isArray(asins) || asins.length === 0) {
+    throw new Error("ASIN list is required for GetItems");
+  }
+  const { associateTag } = getCredentials();
+  const payload = JSON.stringify({
+    ItemIds: asins,
+    Marketplace: "www.amazon.com",
+    PartnerTag: associateTag,
+    PartnerType: "Associates",
+    Resources: [
+      "Images.Primary.Large",
+      "ItemInfo.Title",
+      "ItemInfo.Features",
+      "Offers.Listings.Price",
+      "Offers.Summaries.LowestPrice",
+    ],
+  });
+  return callAmazon(
+    "/paapi5/getitems",
+    "com.amazon.paapi5.v1.ProductAdvertisingAPIv1.GetItems",
+    payload
+  );
 }


### PR DESCRIPTION
## Summary
- switch the Amazon banner to call the Product Advertising API GetItems endpoint for a configurable ASIN list
- display the returned title, hero image, and price for each featured item and drop the static fallback so the banner only surfaces the weekly curated picks
- document the AMAZON_ASINS configuration and remove the unused search helper while reusing shared signing logic for GetItems requests

## Testing
- npm run lint *(fails: command prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68c96ab26b84833296bc541e4c3bb43f