### PR TITLE
Add belt book of the week sidebar

### DIFF
--- a/components/BeltBookBanner.js
+++ b/components/BeltBookBanner.js
@@ -1,0 +1,130 @@
+import React from "react";
+
+const FALLBACK_IMAGE = "/images/book-placeholder.svg";
+
+function Badge({ team, badgeColor, badgeTextColor }) {
+  if (!team) return null;
+
+  const style = {
+    backgroundColor: badgeColor || "rgba(16, 185, 129, 0.12)",
+    color: badgeTextColor || "#065f46",
+  };
+
+  return (
+    <span
+      className="inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold uppercase tracking-wide"
+      style={style}
+    >
+      {team}
+    </span>
+  );
+}
+
+function BookCard({ book }) {
+  const {
+    title,
+    author,
+    team,
+    description,
+    link,
+    image,
+    imageAlt,
+    badgeColor,
+    badgeTextColor,
+    cta,
+    note,
+  } = book;
+
+  const imageSrc = image || FALLBACK_IMAGE;
+  const altText = image
+    ? imageAlt || `Cover of ${title}`
+    : `Placeholder book cover for ${title}`;
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-emerald-100 bg-emerald-50/60 p-3 shadow-sm">
+      <div className="flex gap-3">
+        <div className="relative h-24 w-20 flex-shrink-0 overflow-hidden rounded-xl bg-white ring-1 ring-emerald-100">
+          <img
+            src={imageSrc}
+            alt={altText}
+            loading="lazy"
+            className="h-full w-full object-cover"
+          />
+        </div>
+        <div className="min-w-0 flex-1">
+          <Badge team={team} badgeColor={badgeColor} badgeTextColor={badgeTextColor} />
+          <h3 className="mt-1 text-base font-semibold text-slate-900">{title}</h3>
+          {author && <p className="text-sm text-slate-600">{author}</p>}
+          {description && (
+            <p className="mt-2 text-sm leading-snug text-slate-700">{description}</p>
+          )}
+          {note && (
+            <p className="mt-2 text-xs font-medium uppercase tracking-wide text-emerald-700">
+              {note}
+            </p>
+          )}
+          {link && (
+            <a
+              href={link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-3 inline-flex items-center gap-1 text-sm font-semibold text-emerald-700 transition-colors hover:text-emerald-800"
+              aria-label={`View ${title} on Amazon (opens in a new tab)`}
+            >
+              {cta || "View on Amazon"}
+              <span aria-hidden="true">→</span>
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function BeltBookBanner({
+  title = "Belt Book of the Week",
+  subtitle,
+  description,
+  books = [],
+  disclosure,
+}) {
+  const hasBooks = Array.isArray(books) && books.length > 0;
+
+  return (
+    <div className="lg:sticky lg:top-6">
+      <div className="rounded-3xl border border-emerald-200 bg-white/90 p-5 shadow-md backdrop-blur">
+        <div className="flex flex-col gap-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-600">
+            Weekly Spotlight
+          </p>
+          {title && <h2 className="text-xl font-bold text-emerald-900">{title}</h2>}
+          {subtitle && <p className="text-sm font-semibold text-emerald-700">{subtitle}</p>}
+        </div>
+
+        {description && (
+          <p className="mt-3 text-sm leading-relaxed text-slate-700">{description}</p>
+        )}
+
+        <div className="mt-4 space-y-4">
+          {hasBooks ? (
+            books.map((book, index) => (
+              <BookCard key={`${book.title}-${index}`} book={book} />
+            ))
+          ) : (
+            <p className="text-sm text-slate-600">
+              Add this week&apos;s selections in
+              <code className="mx-1 rounded bg-slate-100 px-1 py-0.5 text-xs text-slate-700">
+                data/beltBookSpotlight.js
+              </code>
+              to feature matchup-specific reads.
+            </p>
+          )}
+        </div>
+
+        {disclosure && (
+          <p className="mt-5 text-xs leading-relaxed text-slate-500">{disclosure}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/data/beltBookSpotlight.js
+++ b/data/beltBookSpotlight.js
@@ -1,0 +1,31 @@
+export const beltBookSpotlight = {
+  title: "Belt Book of the Week",
+  subtitle: "Miami vs. Florida Matchup Picks",
+  description:
+    "Swap in new reads each week to match the upcoming belt showdown. The banner automatically adjusts to however many titles you feature.",
+  books: [
+    {
+      title: "Cane Mutiny: How the Miami Hurricanes Overturned the Football Establishment",
+      author: "Bruce Feldman",
+      team: "Miami Hurricanes",
+      description:
+        "Feldman chronicles the swagger-filled rise of Miami football and the personalities who turned the Hurricanes into a national power—perfect context for this week’s defense.",
+      link: "https://www.amazon.com/Cane-Mutiny-Hurricanes-Overturned-Establishment/dp/141654064X?tag=cfbbelt-20&linkCode=ll1&language=en_US&ref_=as_li_ss_tl",
+      badgeColor: "#005030",
+      badgeTextColor: "#ffffff",
+      cta: "Read on Amazon",
+    },
+    {
+      title: "The Boys from Old Florida: Inside the Gators' Greatest Teams",
+      author: "Buddy Martin",
+      team: "Florida Gators",
+      description:
+        "A behind-the-scenes ride through Florida’s championship eras, from Spurrier to Tebow—ideal pregame material for Gator fans plotting a belt reclaim.",
+      link: "https://www.amazon.com/Boys-Old-Florida-Gators-Greatest/dp/0345509595?tag=cfbbelt-20&linkCode=ll1&language=en_US&ref_=as_li_ss_tl",
+      badgeColor: "#0021A5",
+      badgeTextColor: "#f8fafc",
+      cta: "See the book",
+    },
+  ],
+  disclosure: "As an Amazon Associate, the College Football Belt earns from qualifying purchases.",
+};

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,6 +6,8 @@ import { teamLogoMap, normalizeTeamName, computeRecord } from '../utils/teamUtil
 import Head from 'next/head';
 import AdSlot from '../components/AdSlot';
 import NewsletterSignup from '../components/NewsletterSignup';
+import BeltBookBanner from '../components/BeltBookBanner';
+import { beltBookSpotlight } from '../data/beltBookSpotlight';
 import { fetchFromApi } from '../utils/ssr';
 
 // ...inside your component render where the placeholder was:
@@ -117,12 +119,9 @@ export default function HomePage({ data }) {
   };
 
   return (
-    
-    
     <>
       <NavBar />
-      <div style={{ maxWidth: 900, margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
-         <Head>
+      <Head>
         <title>College Football Belt – The Lineal Title Tracker</title>
         <meta
           name="description"
@@ -134,147 +133,159 @@ export default function HomePage({ data }) {
         <meta property="og:url" content="https://your-domain.com" />
         <meta name="twitter:card" content="summary_large_image" />
       </Head>
+      <div
+        className="mx-auto w-full max-w-6xl px-4 py-6"
+        style={{ fontFamily: 'Arial, sans-serif', color: '#111' }}
+      >
+        <div className="flex flex-col gap-8 lg:flex-row">
+          <main className="flex-1 min-w-0">
+            <div style={{ maxWidth: 900, margin: '0 auto' }}>
+              <div style={{ marginBottom: '1.5rem' }}>
+                <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
+              </div>
 
-      <div style={{ marginBottom: '1.5rem' }}>
-        <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
-      </div>
+              <NewsletterSignup />
 
-      <NewsletterSignup />
+              <div style={{ textAlign: 'center', marginBottom: '0.25rem' }}>
+                <h1 style={{ fontSize: '2rem', margin: 0, color: '#001f3f' }}>The College Football Belt</h1>
+                <div style={{ fontSize: '1.5rem', fontStyle: 'italic', color: '#666', marginTop: '0.5rem' }}>Next Game</div>
+              </div>
 
-      <div style={{ textAlign: 'center', marginBottom: '0.25rem' }}>
-        <h1 style={{ fontSize: '2rem', margin: 0, color: '#001f3f' }}>The College Football Belt</h1>
-        <div style={{ fontSize: '1.5rem', fontStyle: 'italic', color: '#666', marginTop: '0.5rem' }}>Next Game</div>
-      </div>
-
-      <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1.5rem', gap: '2rem', justifyContent: 'center' }}>
-        {[{ name: currentReign.beltHolder, logo: currentLogoUrl }, { name: nextOpponent, logo: opponentLogoUrl }].map((team, idx) => (
-          <div key={idx} style={{ textAlign: 'center' }}>
-            <Link href={`/team/${encodeURIComponent(team.name)}`} legacyBehavior>
-              <a>
-                {team.logo && (
-                  <img src={team.logo} alt={`${team.name} logo`} style={{ height: 100, cursor: 'pointer' }} />
-                )}
-              </a>
-            </Link>
-            <div style={{ marginTop: 4, fontWeight: 600 }}>{team.name}</div>
-          </div>
-        ))}
-      </div>
-
-      <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: '1rem' }}>
-        <thead>
-          <tr>
-            <th style={styles.tableHeader}>Team</th>
-            <th style={styles.tableHeader}>Reigns</th>
-            <th style={styles.tableHeader}>Record</th>
-            <th style={styles.tableHeader}>Win %</th>
-          </tr>
-        </thead>
-        <tbody>
-          {[currentReign.beltHolder, nextOpponent].map((team) => {
-            const record = computeRecord(team, data);
-            const reignsCount = countReigns(team);
-            return (
-              <tr key={team}>
-                <td style={styles.tableCell}>
-                  <Link href={`/team/${encodeURIComponent(team)}`} legacyBehavior>
-                    <a>{team}</a>
-                  </Link>
-                </td>
-                <td style={styles.tableCell}>{reignsCount}</td>
-                <td style={styles.tableCell}>{record.wins} - {record.losses} - {record.ties}</td>
-                <td style={styles.tableCell}>{record.winPct}</td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-      <section className="mb-8">
-        <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>Next Game Preview</h2>
-        <p className="text-gray-900 leading-relaxed">
-          Miami seized the College Football Belt with a commanding 49–12 home win over South Florida. The Hurricanes now prepare for their first defense as they host the Florida Gators in a heated in-state clash. Florida entered the season with the belt, lost it to USF, and already has a chance to win it back one week later. 
-        </p>
-      </section>
-
-      <section className="mb-8">
-        <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>Reign Summary</h2>
-        <p className="text-gray-900 leading-relaxed">
-          {currentReign.beltHolder} captured the College Football Belt on {currentReign.startOfReign} and has defended it{' '}
-          {currentReign.numberOfDefenses} time{currentReign.numberOfDefenses === 1 ? '' : 's'}. This marks their{' '}
-          {countReigns(currentReign.beltHolder)} reign{countReigns(currentReign.beltHolder) === 1 ? '' : 's'} with an overall belt
-          record of {currentRecord.wins}-{currentRecord.losses}-{currentRecord.ties} ({currentRecord.winPct}). The upcoming clash
-          with {nextOpponent} offers a chance to extend the streak and further cement their lineal legacy.
-        </p>
-      </section>
-
-      <section className="mb-8">
-        <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>About The CFB Belt</h2>
-        <div className="text-gray-900 leading-relaxed space-y-4">
-          <p>
-            The College Football Belt is a lineal championship that traces a single path through the sport's history, rewarding
-            each program that manages to topple the reigning holder on the field. Much like boxing’s legendary belts, ownership is
-            determined solely by results: beat the champion and the prize is yours. The tradition begins with first ever football game where Rutgers defeated Princeton 6-4 in 1869. Every subsequent game featuring the belt holder creates a
-            potential transfer of power, making the belt a colorful thread that connects eras, conferences, and generations of
-            players.
-          </p>
-
-          <p>
-            This site exists to make the belt’s journey easy to follow for casual fans and diehards alike. By combining a
-            historical database with up-to-date matchup previews, it highlights the ongoing drama of college football’s most
-            unofficial prize. Visitors can explore past reigns, gauge the significance of upcoming games, or trace how their
-            favorite team might seize the title. Whether you are discovering the concept for the first time or reminiscing about a
-            classic reign, the goal is to offer a central hub for the stories and statistics that define the College Football Belt.
-          </p>
-        </div>
-      </section>
-
-      <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>Past Belt Reigns</h2>
-
-      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-        <thead>
-          <tr>
-            <th style={styles.tableHeader}>Team</th>
-            <th style={styles.tableHeader}>Start</th>
-            <th style={styles.tableHeader}>End</th>
-            <th style={styles.tableHeader}>Defenses</th>
-          </tr>
-        </thead>
-        <tbody>
-          {paginatedReigns.map((reign, idx) => {
-            const logoId = teamLogoMap[normalizeTeamName(reign.beltHolder)];
-            const logoUrl = logoId
-              ? `https://a.espncdn.com/i/teamlogos/ncaa/500/${logoId}.png`
-              : '';
-            return (
-              <tr key={idx} style={{ backgroundColor: idx % 2 === 0 ? '#f5f7fa' : 'white' }}>
-                <td style={styles.tableCell}>
-                  <div style={{ display: 'flex', alignItems: 'center' }}>
-                    {logoUrl && (
-                      <img
-                        src={logoUrl}
-                        alt={`${reign.beltHolder} logo`}
-                        style={{ height: 24, marginRight: 8 }}
-                      />
-                    )}
-                    <Link href={`/team/${encodeURIComponent(reign.beltHolder)}`} legacyBehavior>
-                      <a>{reign.beltHolder}</a>
+              <div style={{ display: 'flex', alignItems: 'center', marginBottom: '1.5rem', gap: '2rem', justifyContent: 'center' }}>
+                {[{ name: currentReign.beltHolder, logo: currentLogoUrl }, { name: nextOpponent, logo: opponentLogoUrl }].map((team, idx) => (
+                  <div key={idx} style={{ textAlign: 'center' }}>
+                    <Link href={`/team/${encodeURIComponent(team.name)}`} legacyBehavior>
+                      <a>
+                        {team.logo && (
+                          <img src={team.logo} alt={`${team.name} logo`} style={{ height: 100, cursor: 'pointer' }} />
+                        )}
+                      </a>
                     </Link>
+                    <div style={{ marginTop: 4, fontWeight: 600 }}>{team.name}</div>
                   </div>
-                </td>
-                <td style={styles.tableCell}>{reign.startOfReign}</td>
-                <td style={styles.tableCell}>{reign.endOfReign}</td>
-                <td style={styles.tableCell}>{reign.numberOfDefenses}</td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+                ))}
+              </div>
 
-      <div style={{ marginTop: '1rem' }}>{getPagination()}</div>
+              <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: '1rem' }}>
+                <thead>
+                  <tr>
+                    <th style={styles.tableHeader}>Team</th>
+                    <th style={styles.tableHeader}>Reigns</th>
+                    <th style={styles.tableHeader}>Record</th>
+                    <th style={styles.tableHeader}>Win %</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[currentReign.beltHolder, nextOpponent].map((team) => {
+                    const record = computeRecord(team, data);
+                    const reignsCount = countReigns(team);
+                    return (
+                      <tr key={team}>
+                        <td style={styles.tableCell}>
+                          <Link href={`/team/${encodeURIComponent(team)}`} legacyBehavior>
+                            <a>{team}</a>
+                          </Link>
+                        </td>
+                        <td style={styles.tableCell}>{reignsCount}</td>
+                        <td style={styles.tableCell}>{record.wins} - {record.losses} - {record.ties}</td>
+                        <td style={styles.tableCell}>{record.winPct}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+              <section className="mb-8">
+                <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>Next Game Preview</h2>
+                <p className="text-gray-900 leading-relaxed">
+                  Miami seized the College Football Belt with a commanding 49–12 home win over South Florida. The Hurricanes now prepare for their first defense as they host the Florida Gators in a heated in-state clash. Florida entered the season with the belt, lost it to USF, and already has a chance to win it back one week later.
+                </p>
+              </section>
 
-    <div style={{ marginBottom: '1.5rem' }}>
-      <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
-    </div>
+              <section className="mb-8">
+                <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>Reign Summary</h2>
+                <p className="text-gray-900 leading-relaxed">
+                  {currentReign.beltHolder} captured the College Football Belt on {currentReign.startOfReign} and has defended it{' '}
+                  {currentReign.numberOfDefenses} time{currentReign.numberOfDefenses === 1 ? '' : 's'}. This marks their{' '}
+                  {countReigns(currentReign.beltHolder)} reign{countReigns(currentReign.beltHolder) === 1 ? '' : 's'} with an overall belt
+                  record of {currentRecord.wins}-{currentRecord.losses}-{currentRecord.ties} ({currentRecord.winPct}). The upcoming clash
+                  with {nextOpponent} offers a chance to extend the streak and further cement their lineal legacy.
+                </p>
+              </section>
+
+              <section className="mb-8">
+                <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>About The CFB Belt</h2>
+                <div className="text-gray-900 leading-relaxed space-y-4">
+                  <p>
+                    The College Football Belt is a lineal championship that traces a single path through the sport's history, rewarding
+                    each program that manages to topple the reigning holder on the field. Much like boxing’s legendary belts, ownership is
+                    determined solely by results: beat the champion and the prize is yours. The tradition begins with first ever football game where Rutgers defeated Princeton 6-4 in 1869. Every subsequent game featuring the belt holder creates a
+                    potential transfer of power, making the belt a colorful thread that connects eras, conferences, and generations of
+                    players.
+                  </p>
+
+                  <p>
+                    This site exists to make the belt’s journey easy to follow for casual fans and diehards alike. By combining a
+                    historical database with up-to-date matchup previews, it highlights the ongoing drama of college football’s most
+                    unofficial prize. Visitors can explore past reigns, gauge the significance of upcoming games, or trace how their
+                    favorite team might seize the title. Whether you are discovering the concept for the first time or reminiscing about a
+                    classic reign, the goal is to offer a central hub for the stories and statistics that define the College Football Belt.
+                  </p>
+                </div>
+              </section>
+
+              <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>Past Belt Reigns</h2>
+
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr>
+                    <th style={styles.tableHeader}>Team</th>
+                    <th style={styles.tableHeader}>Start</th>
+                    <th style={styles.tableHeader}>End</th>
+                    <th style={styles.tableHeader}>Defenses</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {paginatedReigns.map((reign, idx) => {
+                    const logoId = teamLogoMap[normalizeTeamName(reign.beltHolder)];
+                    const logoUrl = logoId
+                      ? `https://a.espncdn.com/i/teamlogos/ncaa/500/${logoId}.png`
+                      : '';
+                    return (
+                      <tr key={idx} style={{ backgroundColor: idx % 2 === 0 ? '#f5f7fa' : 'white' }}>
+                        <td style={styles.tableCell}>
+                          <div style={{ display: 'flex', alignItems: 'center' }}>
+                            {logoUrl && (
+                              <img
+                                src={logoUrl}
+                                alt={`${reign.beltHolder} logo`}
+                                style={{ height: 24, marginRight: 8 }}
+                              />
+                            )}
+                            <Link href={`/team/${encodeURIComponent(reign.beltHolder)}`} legacyBehavior>
+                              <a>{reign.beltHolder}</a>
+                            </Link>
+                          </div>
+                        </td>
+                        <td style={styles.tableCell}>{reign.startOfReign}</td>
+                        <td style={styles.tableCell}>{reign.endOfReign}</td>
+                        <td style={styles.tableCell}>{reign.numberOfDefenses}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+
+              <div style={{ marginTop: '1rem' }}>{getPagination()}</div>
+
+              <div style={{ marginBottom: '1.5rem' }}>
+                <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
+              </div>
+            </div>
+          </main>
+          <aside className="w-full flex-shrink-0 lg:w-80">
+            <BeltBookBanner {...beltBookSpotlight} />
+          </aside>
+        </div>
       </div>
     </>
   );

--- a/public/images/book-placeholder.svg
+++ b/public/images/book-placeholder.svg
@@ -1,0 +1,10 @@
+<svg width="96" height="128" viewBox="0 0 96 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>Book cover placeholder</title>
+  <desc>A stylized outline of an open book used when no cover art is provided.</desc>
+  <rect x="8" y="8" width="80" height="112" rx="10" fill="#ECFDF5" stroke="#34D399" stroke-width="2"/>
+  <path d="M24 32H72" stroke="#059669" stroke-width="4" stroke-linecap="round"/>
+  <path d="M24 48H72" stroke="#34D399" stroke-width="3" stroke-linecap="round"/>
+  <path d="M24 64H56" stroke="#34D399" stroke-width="3" stroke-linecap="round"/>
+  <path d="M24 80H60" stroke="#34D399" stroke-width="3" stroke-linecap="round"/>
+  <path d="M24 96H52" stroke="#A7F3D0" stroke-width="3" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- add a reusable BeltBookBanner component with sticky styling and affiliate-friendly calls-to-action
- provide an editable beltBookSpotlight data source so the weekly matchup books can be updated without touching layout code
- restructure the home page to introduce the right-rail banner and include a branded placeholder cover image

## Testing
- npm run lint *(fails: ESLint must be installed in this repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c97c84ab2083328b67eae031d79567