### PR TITLE
feat: curate amazon banner with selected products

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,16 +49,23 @@ Enable this flag only after your AdSense account and the site have been approved
 
 ### Amazon Product Advertising API
 
-The Amazon banner uses the Product Advertising API to fetch product details. Provide the following credentials in your environment for the `/api/amazon-ads` endpoint:
+The Amazon banner now renders a curated carousel defined in [`data/amazonProducts.js`](data/amazonProducts.js). Each entry can include your full affiliate link, a fallback title, an enticing tagline, and an optional call-to-action line. When the component mounts it derives the ASIN for every active product (either from the `asin` field or from the `/dp/` segment of the URL) and calls the `/api/amazon-ads` route with that list. The API then invokes Amazon's `GetItems` endpoint so the banner pulls back fresh hero imagery and pricing every time a visitor loads the page—keeping you compliant with Amazon's 24-hour pricing policy while letting you swap in a new set of up to six products each week. If the API is temporarily unavailable the cards still render with your copy so the slot never goes blank.
+
+Provide the following credentials in your environment so `/api/amazon-ads` can sign requests:
 
 ```
 AMAZON_ACCESS_KEY="your_access_key"
 AMAZON_SECRET_KEY="your_secret_key"
 AMAZON_ASSOCIATE_TAG="yourtag-20"
-AMAZON_ASINS="B0D8KTKMQW,B00W5VNB80,B07QYCVT29,XXXXXXXXXX"
 ```
 
-Set `AMAZON_ASINS` to a comma-separated list of ASINs you want to feature. The example above uses the ASINs for the Florida Gators wall art, Miami Hurricanes necklace, and fantasy football belt links that ship with this project—replace `XXXXXXXXXX` with the ASIN behind your shortened URL. The banner calls Amazon's `GetItems` endpoint to retrieve the latest product title, hero image, and price for each ASIN so the creative stays compliant with Amazon's 24-hour pricing freshness requirement. If the API request fails or no ASINs are configured, the banner falls back to static SVG panels.
+Optionally set `AMAZON_ASINS` to the same comma-separated ASIN list if you want the API to have a default when called without query parameters:
+
+```
+AMAZON_ASINS="B0D8KTKMQW,B00W5VNB80,B07QYCVT29,REPLACE_WITH_REAL_ASIN"
+```
+
+Edit `data/amazonProducts.js` whenever you want to rotate the featured picks. The repo ships with entries for the Florida Gators wall art, Miami Hurricanes necklace, fantasy football championship belt, and a placeholder slot for your shortened Amazon link—replace `REPLACE_WITH_REAL_ASIN` with the ASIN behind that link so the banner can populate the live price and image automatically. Add or remove objects in this file to keep the banner stocked with up to six curated products.
 
 ## Newsletter signup
 

--- a/data/amazonProducts.js
+++ b/data/amazonProducts.js
@@ -1,0 +1,35 @@
+const amazonProducts = [
+  {
+    asin: "B0D8KTKMQW",
+    link: "https://www.amazon.com/PILOYINDE-Basketball-gators-Bedroom-Florida/dp/B0D8KTKMQW?crid=AHXD6SCISDXA&dib=eyJ2IjoiMSJ9.pk6LKRJrWyC7tifXE2tQbN2UHnVHAwrlI4IPwD53yX2X4rStgfTuv1E_gHFBJRWrYYNyzek8UgroFTHJ2qfBC9oFmhWiy6wCjPYdM_XIc9ixmGdf9mpDyNYY6kFC2lvq9Q-RouPS3N-7afPhlf5A8xbgqwmjs6dGSCNuwfl6LoHCn4NcQk-KFNeveGhubv6-mgtvtFedK9ZOKUEb78pPxg-PyAS1yWzmtKb2Cgn0K0PxHLRP3ELlvTId2RxRFpUWmn2XddGhIf56XIk9eMrKX-Nzb6rvOrDJpD8Tt9d6Ncw.c6dWX31Ia5o_cu0xK9xQRP160sau0_kFYXJ94CuoEl4&dib_tag=se&keywords=florida%2Bgators%2Bgear&qid=1758030266&sprefix=florida%2Bgators%2Bgrea%2Caps%2C196&sr=8-2-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&th=1&linkCode=ll1&tag=cfbbelt-20&linkId=038c37e92c6cfc6ad877d0ab0bbdf5d0&language=en_US&ref_=as_li_ss_tl",
+    fallbackTitle: "Florida Gators Wall Art",
+    tagline:
+      "Turn your fan cave into the Swamp with this bold Gators wall print.",
+    cta: "Shop Florida gear →",
+  },
+  {
+    asin: "B00W5VNB80",
+    link: "https://www.amazon.com/Siskiyou-Miami-Hurricanes-Necklace-Pendant/dp/B00W5VNB80?crid=2JFJ68NWBB0NX&dib=eyJ2IjoiMSJ9.8JZNSm2ose3w2zaLqSd3PBZhCJ-vKRa68bFQC3LPRjgyVZ1NXG-QHYgY8kWt1ATtbrGSzEaY9IuZgACKQMgCy0La7mQzsa9ePeLeJm_YJ3S19do2X48i5kgFKqabrgPsWFjtv7XfN649imR0HHbahJWZLMi_kIaq-vr9papqFqiQZEQVP0dCljv6GgCHPehr5_9ufKPHbB-gzzq_3VOS9yDq44haNznBuNq8TRCYTK61npO2iEG_cQRDsS6HiwKf.0oqJ84BnenLzEa1sL8JwWJfu10NveksJa9PeMblZyRc&dib_tag=se&keywords=umiami%2Bgear&qid=1758030358&sprefix=umiami%2Bgear%2Caps%2C134&sr=8-8&th=1&linkCode=ll1&tag=cfbbelt-20&linkId=d5d97882d4d124be5d5f50200f486d04&language=en_US&ref_=as_li_ss_tl",
+    fallbackTitle: "Miami Hurricanes Necklace",
+    tagline: "Flash The U wherever you go with this everyday necklace.",
+    cta: "Grab the Canes necklace →",
+  },
+  {
+    asin: "B07QYCVT29",
+    link: "https://www.amazon.com/Fantasy-Football-Championship-Belt-Customizable/dp/B07QYCVT29?crid=Q7YY7RE6H763&dib=eyJ2IjoiMSJ9.kwrLnnk6Djg0nFGBOv06n0Po5_hZjoaR-8Y3eBKS7At15wfR7JVGcdnuA6wg0jRDuePBB0gd9Dq77v8rHb5UDF2qnY3U6rcPLJLDg27HDzgPVC9Uq_4yIDLX_YALbnAdPF9Tstf-XS2QrqQyZQa63iY4x8rPVXA2tSdvlzYTLsZBye6JsR_aWH7q3HVWWqlhzP7ZlqDvzxXAe4OccreHLGt_eurivWY6pZB8MYscCOJMjAwgWG5GzBBtWwCdu79pBkcsOfvSbo8NRGxdjvDk8GqCtxQpxS3jLelakOPrgAs.FzhlfvbA3ygxTp0pooYXuj378S2he05Y6CjQoZgls-I&dib_tag=se&keywords=fantasy%2Bfootball%2Bbelt&qid=1758030444&sprefix=fantasy%2Bfootball%2Bbelt%2Caps%2C136&sr=8-1-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&th=1&linkCode=ll1&tag=cfbbelt-20&linkId=6fab320414a8b06b3008c4b4df84b9a9&language=en_US&ref_=as_li_ss_tl",
+    fallbackTitle: "Fantasy Football Championship Belt",
+    tagline:
+      "Hand the champ a heavyweight-worthy fantasy football prize.",
+    cta: "Crown your champion →",
+  },
+  {
+    asin: "REPLACE_WITH_REAL_ASIN",
+    link: "https://amzn.to/3IaxStf",
+    fallbackTitle: "Weekly Amazon Spotlight",
+    tagline:
+      "Update this entry with the product's ASIN to surface live pricing and imagery.",
+    cta: "See this week's deal →",
+  },
+];
+
+export default amazonProducts;


### PR DESCRIPTION
## Summary
- replace the Amazon banner fallback with a curated product carousel driven by a configurable list of ASINs
- add `data/amazonProducts.js` to house weekly affiliate picks, including taglines and CTAs for each card
- document the new curation workflow and environment variables required to fetch live pricing

## Testing
- npm run lint *(fails: npm error 403 Forbidden when attempting to download eslint from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c9afe69d288332b91f62c69703317f