### PR TITLE
Replace Tailwind utility classes with custom CSS

### DIFF
--- a/components/AmazonBanner.js
+++ b/components/AmazonBanner.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import amazonProducts from "../data/amazonProducts";
+import styles from "./AmazonBanner.module.css";
 
 const asinPattern = /^[A-Z0-9]{10}$/;
 
@@ -143,39 +144,39 @@ export default function AmazonBanner() {
       : primaryCards;
 
   return (
-    <div className="mt-8 mb-4">
+    <div className={styles.wrapper}>
       {hasError && (
-        <p className="mb-4 text-center text-sm text-red-600">
+        <p className={styles.errorMessage}>
           We couldn&apos;t refresh today&apos;s Amazon picks. Tap through to see the
           latest price on Amazon.
         </p>
       )}
-      <div className="mx-auto grid max-w-5xl grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className={styles.grid}>
         {cards.map((card) => (
           <a
             key={card.key}
             href={card.link}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex h-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md"
+            className={styles.card}
           >
             {card.image ? (
               <img
                 src={card.image}
                 alt={card.title}
                 loading="lazy"
-                className="block h-32 w-full object-cover"
+                className={styles.cardImage}
               />
             ) : (
-              <div className="flex h-32 w-full items-center justify-center bg-gray-100 text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <div className={styles.cardPlaceholder}>
                 View on Amazon
               </div>
             )}
-            <div className="flex h-full flex-col p-3">
-              <p className="text-sm font-semibold leading-snug text-gray-900">
+            <div className={styles.cardBody}>
+              <p className={styles.cardTitle}>
                 {card.title}
               </p>
-              <p className="mt-2 text-sm font-bold text-emerald-700">
+              <p className={styles.cardPrice}>
                 {card.price
                   ? card.price
                   : loading
@@ -183,12 +184,12 @@ export default function AmazonBanner() {
                   : "See today's price on Amazon"}
               </p>
               {card.tagline && (
-                <p className="mt-3 text-sm text-gray-700">{card.tagline}</p>
+                <p className={styles.cardTagline}>{card.tagline}</p>
               )}
-              <span className="mt-4 inline-flex items-center text-sm font-semibold text-emerald-700">
+              <span className={styles.cardCta}>
                 {card.cta}
                 <svg
-                  className="ml-1 h-4 w-4"
+                  className={styles.cardCtaIcon}
                   viewBox="0 0 20 20"
                   fill="currentColor"
                   aria-hidden="true"

--- a/components/AmazonBanner.module.css
+++ b/components/AmazonBanner.module.css
@@ -1,0 +1,119 @@
+.wrapper {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+.errorMessage {
+  margin-bottom: 1rem;
+  text-align: center;
+  font-size: 0.875rem;
+  color: #dc2626;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+  gap: 1rem;
+  max-width: 64rem;
+  margin: 0 auto;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  border-radius: 0.75rem;
+  border: 1px solid #e5e7eb;
+  background-color: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
+}
+
+.cardImage {
+  display: block;
+  width: 100%;
+  height: 8rem;
+  object-fit: cover;
+}
+
+.cardPlaceholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 8rem;
+  background-color: #f3f4f6;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #6b7280;
+}
+
+.cardBody {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 0.75rem;
+}
+
+.cardTitle {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: #111827;
+}
+
+.cardPrice {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: #047857;
+}
+
+.cardTagline {
+  margin-top: 0.75rem;
+  font-size: 0.875rem;
+  color: #374151;
+  line-height: 1.5;
+}
+
+.cardCta {
+  margin-top: 1rem;
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #047857;
+  transition: color 0.2s ease;
+}
+
+.card:hover .cardCta {
+  color: #065f46;
+}
+
+.cardCtaIcon {
+  margin-left: 0.25rem;
+  width: 1rem;
+  height: 1rem;
+}
+
+@media (min-width: 640px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/components/BeltBookBanner.js
+++ b/components/BeltBookBanner.js
@@ -1,4 +1,5 @@
 import React from "react";
+import styles from "./BeltBookBanner.module.css";
 
 const FALLBACK_IMAGE = "/images/book-placeholder.svg";
 
@@ -11,10 +12,7 @@ function Badge({ team, badgeColor, badgeTextColor }) {
   };
 
   return (
-    <span
-      className="inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold uppercase tracking-wide"
-      style={style}
-    >
+    <span className={styles.badge} style={style}>
       {team}
     </span>
   );
@@ -41,25 +39,25 @@ function BookCard({ book }) {
     : `Placeholder book cover for ${title}`;
 
   return (
-    <div className="overflow-hidden rounded-2xl border border-emerald-100 bg-emerald-50/60 p-3 shadow-sm">
-      <div className="flex gap-3">
-        <div className="relative h-24 w-20 flex-shrink-0 overflow-hidden rounded-xl bg-white ring-1 ring-emerald-100">
+    <div className={styles.bookCard}>
+      <div className={styles.bookCardContent}>
+        <div className={styles.bookImageWrapper}>
           <img
             src={imageSrc}
             alt={altText}
             loading="lazy"
-            className="h-full w-full object-cover"
+            className={styles.bookImage}
           />
         </div>
-        <div className="min-w-0 flex-1">
+        <div className={styles.bookDetails}>
           <Badge team={team} badgeColor={badgeColor} badgeTextColor={badgeTextColor} />
-          <h3 className="mt-1 text-base font-semibold text-slate-900">{title}</h3>
-          {author && <p className="text-sm text-slate-600">{author}</p>}
+          <h3 className={styles.bookTitle}>{title}</h3>
+          {author && <p className={styles.bookAuthor}>{author}</p>}
           {description && (
-            <p className="mt-2 text-sm leading-snug text-slate-700">{description}</p>
+            <p className={styles.bookDescription}>{description}</p>
           )}
           {note && (
-            <p className="mt-2 text-xs font-medium uppercase tracking-wide text-emerald-700">
+            <p className={styles.bookNote}>
               {note}
             </p>
           )}
@@ -68,7 +66,7 @@ function BookCard({ book }) {
               href={link}
               target="_blank"
               rel="noopener noreferrer"
-              className="mt-3 inline-flex items-center gap-1 text-sm font-semibold text-emerald-700 transition-colors hover:text-emerald-800"
+              className={styles.bookLink}
               aria-label={`View ${title} on Amazon (opens in a new tab)`}
             >
               {cta || "View on Amazon"}
@@ -91,29 +89,27 @@ export default function BeltBookBanner({
   const hasBooks = Array.isArray(books) && books.length > 0;
 
   return (
-    <div className="lg:sticky lg:top-6">
-      <div className="rounded-3xl border border-emerald-200 bg-white/90 p-5 shadow-md backdrop-blur">
-        <div className="flex flex-col gap-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-600">
-            Weekly Spotlight
-          </p>
-          {title && <h2 className="text-xl font-bold text-emerald-900">{title}</h2>}
-          {subtitle && <p className="text-sm font-semibold text-emerald-700">{subtitle}</p>}
+    <div className={styles.stickyWrapper}>
+      <div className={styles.banner}>
+        <div className={styles.header}>
+          <p className={styles.headerLabel}>Weekly Spotlight</p>
+          {title && <h2 className={styles.headerTitle}>{title}</h2>}
+          {subtitle && <p className={styles.headerSubtitle}>{subtitle}</p>}
         </div>
 
         {description && (
-          <p className="mt-3 text-sm leading-relaxed text-slate-700">{description}</p>
+          <p className={styles.description}>{description}</p>
         )}
 
-        <div className="mt-4 space-y-4">
+        <div className={styles.bookList}>
           {hasBooks ? (
             books.map((book, index) => (
               <BookCard key={`${book.title}-${index}`} book={book} />
             ))
           ) : (
-            <p className="text-sm text-slate-600">
+            <p className={styles.emptyMessage}>
               Add this week&apos;s selections in
-              <code className="mx-1 rounded bg-slate-100 px-1 py-0.5 text-xs text-slate-700">
+              <code className={styles.codeInline}>
                 data/beltBookSpotlight.js
               </code>
               to feature matchup-specific reads.
@@ -122,7 +118,7 @@ export default function BeltBookBanner({
         </div>
 
         {disclosure && (
-          <p className="mt-5 text-xs leading-relaxed text-slate-500">{disclosure}</p>
+          <p className={styles.disclosure}>{disclosure}</p>
         )}
       </div>
     </div>

--- a/components/BeltBookBanner.module.css
+++ b/components/BeltBookBanner.module.css
@@ -1,0 +1,179 @@
+.stickyWrapper {
+  position: static;
+}
+
+.banner {
+  border: 1px solid #a7f3d0;
+  background-color: rgba(255, 255, 255, 0.9);
+  border-radius: 1.5rem;
+  padding: 1.25rem;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(8px);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.headerLabel {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: #059669;
+}
+
+.headerTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #064e3b;
+}
+
+.headerSubtitle {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #047857;
+}
+
+.description {
+  margin: 0.75rem 0 0;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: #334155;
+}
+
+.bookList {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.emptyMessage {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: #475569;
+}
+
+.codeInline {
+  margin: 0 0.25rem;
+  border-radius: 0.25rem;
+  background-color: #f1f5f9;
+  padding: 0.125rem 0.25rem;
+  font-size: 0.75rem;
+  color: #334155;
+}
+
+.disclosure {
+  margin-top: 1.25rem;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  color: #64748b;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  line-height: 1;
+}
+
+.bookCard {
+  overflow: hidden;
+  border-radius: 1rem;
+  border: 1px solid #d1fae5;
+  background-color: rgba(236, 253, 245, 0.6);
+  padding: 0.75rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+}
+
+.bookCardContent {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.bookImageWrapper {
+  position: relative;
+  height: 6rem;
+  width: 5rem;
+  flex-shrink: 0;
+  overflow: hidden;
+  border-radius: 0.75rem;
+  background-color: #ffffff;
+  border: 1px solid #d1fae5;
+}
+
+.bookImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.bookDetails {
+  min-width: 0;
+  flex: 1;
+}
+
+.bookTitle {
+  margin: 0.25rem 0 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.bookAuthor {
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+  color: #475569;
+}
+
+.bookDescription {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: #334155;
+}
+
+.bookNote {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #047857;
+}
+
+.bookLink {
+  margin-top: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #047857;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.bookLink:hover {
+  color: #065f46;
+}
+
+@media (min-width: 1024px) {
+  .stickyWrapper {
+    position: sticky;
+    top: 1.5rem;
+  }
+}

--- a/components/Collapsible.js
+++ b/components/Collapsible.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import styles from './Collapsible.module.css';
 
 export function Collapsible({ children }) {
   return <div>{children}</div>;
@@ -6,7 +6,7 @@ export function Collapsible({ children }) {
 
 export function CollapsibleTrigger({ children, onClick }) {
   return (
-    <button onClick={onClick} className="text-blue-600 underline text-sm">
+    <button onClick={onClick} className={styles.trigger}>
       {children}
     </button>
   );

--- a/components/Collapsible.module.css
+++ b/components/Collapsible.module.css
@@ -1,0 +1,18 @@
+.trigger {
+  color: #2563eb;
+  text-decoration: underline;
+  font-size: 0.875rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.trigger:hover {
+  color: #1d4ed8;
+}
+
+.trigger:focus {
+  outline: 2px solid #93c5fd;
+  outline-offset: 2px;
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -9,10 +9,11 @@ import NewsletterSignup from '../components/NewsletterSignup';
 import BeltBookBanner from '../components/BeltBookBanner';
 import { beltBookSpotlight } from '../data/beltBookSpotlight';
 import { fetchFromApi } from '../utils/ssr';
+import homeStyles from '../styles/HomePage.module.css';
 
 // ...inside your component render where the placeholder was:
 
-const styles = {
+const tableStyles = {
   tableHeader: {
     textAlign: 'left',
     padding: '10px 12px',
@@ -133,12 +134,9 @@ export default function HomePage({ data }) {
         <meta property="og:url" content="https://your-domain.com" />
         <meta name="twitter:card" content="summary_large_image" />
       </Head>
-      <div
-        className="mx-auto w-full max-w-7xl px-4 py-6"
-        style={{ fontFamily: 'Arial, sans-serif', color: '#111' }}
-      >
-        <div className="flex flex-col gap-8 lg:flex-row lg:items-start">
-          <main className="flex-1 min-w-0">
+      <div className={homeStyles.pageContainer}>
+        <div className={homeStyles.layout}>
+          <main className={homeStyles.mainContent}>
             <div style={{ maxWidth: 900, margin: '0 auto', width: '100%' }}>
               <div style={{ marginBottom: '1.5rem' }}>
                 <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
@@ -169,10 +167,10 @@ export default function HomePage({ data }) {
               <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: '1rem' }}>
                 <thead>
                   <tr>
-                    <th style={styles.tableHeader}>Team</th>
-                    <th style={styles.tableHeader}>Reigns</th>
-                    <th style={styles.tableHeader}>Record</th>
-                    <th style={styles.tableHeader}>Win %</th>
+                    <th style={tableStyles.tableHeader}>Team</th>
+                    <th style={tableStyles.tableHeader}>Reigns</th>
+                    <th style={tableStyles.tableHeader}>Record</th>
+                    <th style={tableStyles.tableHeader}>Win %</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -181,29 +179,29 @@ export default function HomePage({ data }) {
                     const reignsCount = countReigns(team);
                     return (
                       <tr key={team}>
-                        <td style={styles.tableCell}>
+                        <td style={tableStyles.tableCell}>
                           <Link href={`/team/${encodeURIComponent(team)}`} legacyBehavior>
                             <a>{team}</a>
                           </Link>
                         </td>
-                        <td style={styles.tableCell}>{reignsCount}</td>
-                        <td style={styles.tableCell}>{record.wins} - {record.losses} - {record.ties}</td>
-                        <td style={styles.tableCell}>{record.winPct}</td>
+                        <td style={tableStyles.tableCell}>{reignsCount}</td>
+                        <td style={tableStyles.tableCell}>{record.wins} - {record.losses} - {record.ties}</td>
+                        <td style={tableStyles.tableCell}>{record.winPct}</td>
                       </tr>
                     );
                   })}
                 </tbody>
               </table>
-              <section className="mb-8">
-                <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>Next Game Preview</h2>
-                <p className="text-gray-900 leading-relaxed">
+              <section className={homeStyles.section}>
+                <h2 className={homeStyles.sectionTitle}>Next Game Preview</h2>
+                <p className={homeStyles.bodyText}>
                   Miami seized the College Football Belt with a commanding 49–12 home win over South Florida. The Hurricanes now prepare for their first defense as they host the Florida Gators in a heated in-state clash. Florida entered the season with the belt, lost it to USF, and already has a chance to win it back one week later.
                 </p>
               </section>
 
-              <section className="mb-8">
-                <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>Reign Summary</h2>
-                <p className="text-gray-900 leading-relaxed">
+              <section className={homeStyles.section}>
+                <h2 className={homeStyles.sectionTitle}>Reign Summary</h2>
+                <p className={homeStyles.bodyText}>
                   {currentReign.beltHolder} captured the College Football Belt on {currentReign.startOfReign} and has defended it{' '}
                   {currentReign.numberOfDefenses} time{currentReign.numberOfDefenses === 1 ? '' : 's'}. This marks their{' '}
                   {countReigns(currentReign.beltHolder)} reign{countReigns(currentReign.beltHolder) === 1 ? '' : 's'} with an overall belt
@@ -212,9 +210,9 @@ export default function HomePage({ data }) {
                 </p>
               </section>
 
-              <section className="mb-8">
-                <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>About The CFB Belt</h2>
-                <div className="text-gray-900 leading-relaxed space-y-4">
+              <section className={homeStyles.section}>
+                <h2 className={homeStyles.sectionTitle}>About The CFB Belt</h2>
+                <div className={homeStyles.bodyTextGroup}>
                   <p>
                     The College Football Belt is a lineal championship that traces a single path through the sport's history, rewarding
                     each program that manages to topple the reigning holder on the field. Much like boxing’s legendary belts, ownership is
@@ -233,15 +231,15 @@ export default function HomePage({ data }) {
                 </div>
               </section>
 
-              <h2 className="text-2xl font-semibold mb-4" style={{ color: '#001f3f' }}>Past Belt Reigns</h2>
+              <h2 className={homeStyles.sectionTitle}>Past Belt Reigns</h2>
 
               <table style={{ width: '100%', borderCollapse: 'collapse' }}>
                 <thead>
                   <tr>
-                    <th style={styles.tableHeader}>Team</th>
-                    <th style={styles.tableHeader}>Start</th>
-                    <th style={styles.tableHeader}>End</th>
-                    <th style={styles.tableHeader}>Defenses</th>
+                    <th style={tableStyles.tableHeader}>Team</th>
+                    <th style={tableStyles.tableHeader}>Start</th>
+                    <th style={tableStyles.tableHeader}>End</th>
+                    <th style={tableStyles.tableHeader}>Defenses</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -252,7 +250,7 @@ export default function HomePage({ data }) {
                       : '';
                     return (
                       <tr key={idx} style={{ backgroundColor: idx % 2 === 0 ? '#f5f7fa' : 'white' }}>
-                        <td style={styles.tableCell}>
+                        <td style={tableStyles.tableCell}>
                           <div style={{ display: 'flex', alignItems: 'center' }}>
                             {logoUrl && (
                               <img
@@ -266,9 +264,9 @@ export default function HomePage({ data }) {
                             </Link>
                           </div>
                         </td>
-                        <td style={styles.tableCell}>{reign.startOfReign}</td>
-                        <td style={styles.tableCell}>{reign.endOfReign}</td>
-                        <td style={styles.tableCell}>{reign.numberOfDefenses}</td>
+                        <td style={tableStyles.tableCell}>{reign.startOfReign}</td>
+                        <td style={tableStyles.tableCell}>{reign.endOfReign}</td>
+                        <td style={tableStyles.tableCell}>{reign.numberOfDefenses}</td>
                       </tr>
                     );
                   })}
@@ -282,7 +280,7 @@ export default function HomePage({ data }) {
               </div>
             </div>
           </main>
-          <aside className="w-full flex-shrink-0 lg:w-80">
+          <aside className={homeStyles.sidebar}>
             <BeltBookBanner {...beltBookSpotlight} />
           </aside>
         </div>

--- a/styles/HomePage.module.css
+++ b/styles/HomePage.module.css
@@ -1,0 +1,60 @@
+.pageContainer {
+  margin: 0 auto;
+  width: 100%;
+  max-width: 80rem;
+  padding: 1.5rem 1rem;
+  font-family: Arial, sans-serif;
+  color: #111;
+}
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  align-items: stretch;
+}
+
+.mainContent {
+  flex: 1;
+  min-width: 0;
+}
+
+.section {
+  margin-bottom: 2rem;
+}
+
+.sectionTitle {
+  color: #001f3f;
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.bodyText {
+  color: #1f2937;
+  line-height: 1.7;
+}
+
+.bodyTextGroup {
+  color: #1f2937;
+  line-height: 1.7;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sidebar {
+  width: 100%;
+  flex-shrink: 0;
+}
+
+@media (min-width: 1024px) {
+  .layout {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .sidebar {
+    width: 20rem;
+  }
+}


### PR DESCRIPTION
## Summary
- replace Tailwind utility classes on the home page with a dedicated CSS module to control layout and typography
- restyle BeltBookBanner, AmazonBanner, and Collapsible components with custom CSS modules that mirror the intended Tailwind design

## Testing
- npm run lint *(prompts to configure ESLint; cancelled to avoid modifying the project configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b88f819c8332b20b4106a9a3f224