### PR TITLE
Refine Amazon affiliate banner layout

### DIFF
--- a/components/AmazonBanner.js
+++ b/components/AmazonBanner.js
@@ -48,14 +48,12 @@ export default function AmazonBanner({ count = 3, startIndex = 0 } = {}) {
     : 0;
 
   const [productMap, setProductMap] = useState(() => Object.create(null));
-  const [loading, setLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
 
   useEffect(() => {
     const asins = amazonProducts.map(deriveAsin).filter(Boolean);
 
     if (asins.length === 0) {
-      setLoading(false);
       return undefined;
     }
 
@@ -86,10 +84,6 @@ export default function AmazonBanner({ count = 3, startIndex = 0 } = {}) {
         console.error(error);
         setHasError(true);
         setProductMap(Object.create(null));
-      } finally {
-        if (isActive) {
-          setLoading(false);
-        }
       }
     }
 
@@ -112,9 +106,11 @@ export default function AmazonBanner({ count = 3, startIndex = 0 } = {}) {
         product.tagline ||
         "Amazon pick";
       const image = details?.image || product.fallbackImage || null;
-      const price = details?.price;
-      const tagline = product.tagline;
-      const cta = product.cta || "See it on Amazon →";
+      const description =
+        product.tagline ||
+        product.fallbackTitle ||
+        details?.title ||
+        title;
       const key = asin || `${link || "amazon-product"}-${index}`;
 
       if (!link || !title) {
@@ -126,9 +122,7 @@ export default function AmazonBanner({ count = 3, startIndex = 0 } = {}) {
         link,
         title,
         image,
-        price,
-        tagline,
-        cta,
+        description,
       };
     })
     .filter(Boolean);
@@ -162,6 +156,7 @@ export default function AmazonBanner({ count = 3, startIndex = 0 } = {}) {
             target="_blank"
             rel="noopener noreferrer"
             className={styles.card}
+            title={card.title}
           >
             {card.image ? (
               <img
@@ -176,34 +171,9 @@ export default function AmazonBanner({ count = 3, startIndex = 0 } = {}) {
               </div>
             )}
             <div className={styles.cardBody}>
-              <p className={styles.cardTitle}>
-                {card.title}
-              </p>
-              <p className={styles.cardPrice}>
-                {card.price
-                  ? card.price
-                  : loading
-                  ? "Checking today's price..."
-                  : "See today's price on Amazon"}
-              </p>
-              {card.tagline && (
-                <p className={styles.cardTagline}>{card.tagline}</p>
+              {card.description && (
+                <p className={styles.cardDescription}>{card.description}</p>
               )}
-              <span className={styles.cardCta}>
-                {card.cta}
-                <svg
-                  className={styles.cardCtaIcon}
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    fillRule="evenodd"
-                    d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                    clipRule="evenodd"
-                  />
-                </svg>
-              </span>
             </div>
           </a>
         ))}

--- a/components/AmazonBanner.module.css
+++ b/components/AmazonBanner.module.css
@@ -1,6 +1,6 @@
 .wrapper {
-  margin-top: 2rem;
-  margin-bottom: 1rem;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
 .errorMessage {
@@ -12,10 +12,9 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(1, minmax(0, 1fr));
-  gap: 1rem;
-  max-width: 64rem;
-  margin: 0 auto;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.75rem;
+  width: 100%;
 }
 
 .card {
@@ -39,8 +38,9 @@
 .cardImage {
   display: block;
   width: 100%;
-  height: 8rem;
-  object-fit: cover;
+  height: 8.5rem;
+  object-fit: contain;
+  padding: 0.5rem;
 }
 
 .cardPlaceholder {
@@ -48,72 +48,29 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 8rem;
+  height: 8.5rem;
   background-color: #f3f4f6;
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: #6b7280;
+  padding: 0.5rem;
 }
 
 .cardBody {
   display: flex;
   flex-direction: column;
+  justify-content: center;
+  align-items: center;
   height: 100%;
-  padding: 0.75rem;
+  padding: 0.75rem 1rem 1rem;
 }
 
-.cardTitle {
+.cardDescription {
   margin: 0;
   font-size: 0.875rem;
-  font-weight: 600;
-  line-height: 1.4;
-  color: #111827;
-}
-
-.cardPrice {
-  margin-top: 0.5rem;
-  font-size: 0.875rem;
-  font-weight: 700;
-  color: #047857;
-}
-
-.cardTagline {
-  margin-top: 0.75rem;
-  font-size: 0.875rem;
-  color: #374151;
   line-height: 1.5;
-}
-
-.cardCta {
-  margin-top: 1rem;
-  display: inline-flex;
-  align-items: center;
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: #047857;
-  transition: color 0.2s ease;
-}
-
-.card:hover .cardCta {
-  color: #065f46;
-}
-
-.cardCtaIcon {
-  margin-left: 0.25rem;
-  width: 1rem;
-  height: 1rem;
-}
-
-@media (min-width: 640px) {
-  .grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1024px) {
-  .grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
+  color: #1f2937;
+  text-align: center;
 }


### PR DESCRIPTION
## Summary
- simplify the Amazon banner card content to only render imagery and descriptive copy
- streamline the Product Advertising API fetch logic by removing the unused loading state
- restyle the banner so cards stretch full width, center their descriptions, and display uncropped images

## Testing
- npm run lint *(fails: prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c886ac3c8332aa6bee885d4a942e