### PR TITLE
Make homepage ad slots full width and adjust banners

### DIFF
--- a/components/AmazonBanner.js
+++ b/components/AmazonBanner.js
@@ -100,17 +100,16 @@ export default function AmazonBanner({ count = 3, startIndex = 0 } = {}) {
       const asin = deriveAsin(product);
       const details = asin ? productMap[asin] : undefined;
       const link = product.link || details?.link;
-      const title =
-        details?.title ||
+      const fallbackTitle =
         product.fallbackTitle ||
-        product.tagline ||
         "Amazon pick";
+      const title = details?.title || fallbackTitle;
       const image = details?.image || product.fallbackImage || null;
-      const description =
-        product.tagline ||
-        product.fallbackTitle ||
+      const displayTitle =
         details?.title ||
-        title;
+        product.fallbackTitle ||
+        fallbackTitle;
+      const price = details?.price || null;
       const key = asin || `${link || "amazon-product"}-${index}`;
 
       if (!link || !title) {
@@ -122,7 +121,8 @@ export default function AmazonBanner({ count = 3, startIndex = 0 } = {}) {
         link,
         title,
         image,
-        description,
+        displayTitle,
+        price,
       };
     })
     .filter(Boolean);
@@ -171,8 +171,9 @@ export default function AmazonBanner({ count = 3, startIndex = 0 } = {}) {
               </div>
             )}
             <div className={styles.cardBody}>
-              {card.description && (
-                <p className={styles.cardDescription}>{card.description}</p>
+              <p className={styles.cardTitle}>{card.displayTitle}</p>
+              {card.price && (
+                <p className={styles.cardPrice}>{card.price}</p>
               )}
             </div>
           </a>

--- a/components/AmazonBanner.module.css
+++ b/components/AmazonBanner.module.css
@@ -63,14 +63,24 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 0.35rem;
   height: 100%;
   padding: 0.75rem 1rem 1rem;
 }
 
-.cardDescription {
+.cardTitle {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: #111827;
+  font-weight: 600;
+  text-align: center;
+}
+
+.cardPrice {
   margin: 0;
   font-size: 0.875rem;
-  line-height: 1.5;
-  color: #1f2937;
+  font-weight: 600;
+  color: #047857;
   text-align: center;
 }

--- a/components/BeltBookBanner.module.css
+++ b/components/BeltBookBanner.module.css
@@ -1,12 +1,17 @@
 .stickyWrapper {
   position: static;
+  display: flex;
+  justify-content: center;
 }
 
 .banner {
   border: 1px solid #a7f3d0;
   background-color: rgba(255, 255, 255, 0.9);
   border-radius: 1.5rem;
-  padding: 1.25rem;
+  width: 100%;
+  max-width: 18rem;
+  margin: 0 auto;
+  padding: 1rem;
   box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
   backdrop-filter: blur(8px);
 }
@@ -42,9 +47,9 @@
 
 .bookList {
   margin-top: 1rem;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
-  grid-template-columns: 1fr;
 }
 
 .emptyMessage {
@@ -164,18 +169,6 @@
 
   .bookDetails {
     width: 100%;
-  }
-}
-
-@media (min-width: 640px) {
-  .bookList {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1024px) {
-  .bookList {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -135,16 +135,17 @@ export default function HomePage({ data }) {
         <meta name="twitter:card" content="summary_large_image" />
       </Head>
       <div className={homeStyles.pageContainer}>
+        <div
+          className={`${homeStyles.fullWidthAd} ${homeStyles.topFullWidthAd}`}
+        >
+          <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
+        </div>
         <div className={homeStyles.preContent}>
-          <div className={homeStyles.adWrapper}>
-            <AdSlot AdSlot="9168138847" enabled={data.length > 0} />
-          </div>
-
           <NewsletterSignup />
         </div>
         <div className={homeStyles.layout}>
           <main className={homeStyles.mainContent}>
-            <div style={{ maxWidth: 900, margin: '0 auto', width: '100%' }}>
+            <div className={homeStyles.mainInner}>
               <div style={{ textAlign: 'center', marginBottom: '0.25rem' }}>
                 <h1 style={{ fontSize: '2rem', margin: 0, color: '#001f3f' }}>The College Football Belt</h1>
                 <div style={{ fontSize: '1.5rem', fontStyle: 'italic', color: '#666', marginTop: '0.5rem' }}>Next Game</div>
@@ -275,14 +276,15 @@ export default function HomePage({ data }) {
               </table>
 
               <div style={{ marginTop: '1rem' }}>{getPagination()}</div>
-
-              <div style={{ marginBottom: '1.5rem' }}>
-                <AdSlot
-                  AdSlot="9168138847"
-                  enabled={data.length > 0}
-                  startIndex={3}
-                />
-              </div>
+            </div>
+            <div
+              className={`${homeStyles.fullWidthAd} ${homeStyles.bottomFullWidthAd}`}
+            >
+              <AdSlot
+                AdSlot="9168138847"
+                enabled={data.length > 0}
+                startIndex={3}
+              />
             </div>
           </main>
           <aside className={homeStyles.sidebar}>

--- a/styles/HomePage.module.css
+++ b/styles/HomePage.module.css
@@ -20,13 +20,40 @@
   margin: 0 auto 2rem;
 }
 
-.adWrapper {
+.fullWidthAd {
+  width: 100vw;
+  max-width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
   margin-bottom: 1.5rem;
+  padding: 0 1rem;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+}
+
+.fullWidthAd > * {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.topFullWidthAd {
+  margin-top: 1rem;
+}
+
+.bottomFullWidthAd {
+  margin-top: 2rem;
 }
 
 .mainContent {
   flex: 1;
   min-width: 0;
+}
+
+.mainInner {
+  max-width: 56.25rem;
+  margin: 0 auto;
+  width: 100%;
 }
 
 .section {


### PR DESCRIPTION
## Summary
- allow the top and bottom homepage ad slots to render in a full-width container and center their content
- surface Amazon-provided product names and pricing in the fallback banner instead of custom taglines
- narrow the Belt Book banner sidebar widget and force its book cards to stack in a single column

## Testing
- npm run lint *(fails: prompts to configure ESLint before running)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ce377d6c83329a7a86046c11f2ed