### PR TITLE
Fix Amazon banner layout and content

### DIFF
--- a/styles/FullWidthAd.module.css
+++ b/styles/FullWidthAd.module.css
@@ -1,10 +1,7 @@
 .fullWidthAd {
-  width: 100vw;
-  max-width: 100vw;
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
-  margin-bottom: 1.5rem;
-  padding: 0 1rem;
+  width: 100%;
+  margin: 0 auto 1.5rem;
+  padding: 0;
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -13,6 +10,10 @@
 .inner {
   flex: 1 1 0;
   min-width: 0;
+  width: 100%;
+  max-width: 56.25rem;
+  padding: 0 1rem;
+  box-sizing: border-box;
 }
 
 .spaced {


### PR DESCRIPTION
## Summary
- limit the Amazon banner cards to the product title and imagery so the affiliate slot only surfaces the item name
- add a fallback image URL derived from the ASIN/tag when the Product Advertising API does not return artwork
- update the full-width ad wrapper styles so the bottom bar stays aligned with the main content instead of overflowing off-screen

## Testing
- npm run lint *(fails: command prompts to configure ESLint interactively in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1c2199f88332a17a4a37f9c241e7