### PR TITLE
Adjust ad banner styling and fix coaster product image

### DIFF
--- a/components/AmazonBanner.module.css
+++ b/components/AmazonBanner.module.css
@@ -1,6 +1,6 @@
 .wrapper {
-  margin-top: 1.5rem;
-  margin-bottom: 1.5rem;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 }
 
 .errorMessage {

--- a/data/amazonProducts.js
+++ b/data/amazonProducts.js
@@ -15,10 +15,12 @@ const amazonProducts = [
     cta: "Grab the Canes necklace →",
   },
   {
-    link: "https://amzn.to/3KfWkKh",
-    fallbackTitle: "Featured Tailgate Upgrade",
-    tagline: "Tap through for our latest belt-country tailgate pick.",
-    cta: "Check the featured pick →",
+    link: "https://amzn.to/3K9vyDt",
+    fallbackTitle: "YouTheFan NCAA Team Spirit Coasters",
+    fallbackImage: "/images/sport-fan-coasters.svg",
+    tagline:
+      "Set out these layered team coasters to keep your tailgate surfaces spotless.",
+    cta: "Dress up the drink table →",
   },
   {
     asin: "B07QYCVT29",

--- a/public/images/sport-fan-coasters.svg
+++ b/public/images/sport-fan-coasters.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 200" role="img" aria-labelledby="title desc">
+  <title id="title">Stylized illustration of stacked team drink coasters</title>
+  <desc id="desc">Three overlapping coasters in Florida-inspired colors on a soft gradient background.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f8fafc" />
+      <stop offset="100%" stop-color="#e2e8f0" />
+    </linearGradient>
+    <linearGradient id="orangeRing" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fb923c" />
+      <stop offset="100%" stop-color="#ea580c" />
+    </linearGradient>
+    <linearGradient id="blueRing" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+    <linearGradient id="greenRing" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#10b981" />
+      <stop offset="100%" stop-color="#059669" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="rgba(15,23,42,0.12)" />
+    </filter>
+  </defs>
+  <rect width="320" height="200" rx="24" fill="url(#bg)" />
+  <g filter="url(#shadow)" transform="translate(32 16)">
+    <circle cx="70" cy="100" r="62" fill="#fff" stroke="url(#orangeRing)" stroke-width="10" />
+    <circle cx="70" cy="100" r="34" fill="rgba(251,146,60,0.15)" />
+    <circle cx="160" cy="78" r="66" fill="#fff" stroke="url(#blueRing)" stroke-width="12" />
+    <circle cx="160" cy="78" r="38" fill="rgba(37,99,235,0.18)" />
+    <circle cx="222" cy="122" r="58" fill="#fff" stroke="url(#greenRing)" stroke-width="10" />
+    <circle cx="222" cy="122" r="32" fill="rgba(16,185,129,0.2)" />
+  </g>
+  <text x="160" y="176" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="16" font-weight="600" fill="#1f2937">
+    Game day table essentials
+  </text>
+</svg>

--- a/styles/FullWidthAd.module.css
+++ b/styles/FullWidthAd.module.css
@@ -1,29 +1,30 @@
 .fullWidthAd {
   width: 100%;
-  margin: 0 auto 1.5rem;
+  margin: 0 0 1rem;
   padding: 0;
   box-sizing: border-box;
-  display: flex;
-  justify-content: center;
 }
 
 .inner {
-  flex: 1 1 0;
-  min-width: 0;
   width: 100%;
-  max-width: 56.25rem;
-  padding: 0 1rem;
+  padding: 0;
   box-sizing: border-box;
 }
 
-.spaced {
-  margin-top: 1.5rem;
+.inner :global(.adsbygoogle) {
+  display: block;
+  width: 100%;
+  margin: 0;
 }
 
-.tightTop {
+.spaced {
   margin-top: 1rem;
 }
 
+.tightTop {
+  margin-top: 0.5rem;
+}
+
 .looseBottom {
-  margin-top: 2rem;
+  margin-top: 1.5rem;
 }


### PR DESCRIPTION
## Summary
- point the coaster affiliate slot at the refreshed short link and supply a branded fallback image so the card never renders blank
- add an SVG illustration for the coaster product that can be used whenever Amazon imagery fails to load
- restyle the shared ad wrapper to stretch edge-to-edge with slimmer vertical spacing, keeping the Amazon banner margins in sync

## Testing
- `npm run lint` *(fails: prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2237ed208332958ed74cf3c03bcb