### PR TITLE
Reassign Amazon banner slots to belt, coasters, and LEGO picks

### DIFF
--- a/data/amazonProducts.js
+++ b/data/amazonProducts.js
@@ -38,12 +38,12 @@ const amazonProducts = [
     cta: "Dress up the drink table →",
   },
   {
-    asin: "B0B7QPYZVP",
-    link: "https://www.amazon.com/LEGO-Ideas-Table-Football-Building/dp/B0B7QPYZVP?tag=cfbbelt-20&linkCode=ll1&language=en_US&ref_=as_li_ss_tl",
-    fallbackTitle: "LEGO Ideas Table Football (21337)",
+    asin: "B0DGFW36YX",
+    link: "https://www.amazon.com/Football-Players-School-Birthday-Classroom/dp/B0DGFW36YX/ref=sxin_17_pa_sp_search_thematic_sspa?content-id=amzn1.sym.af2622b9-f19b-41dc-b23f-021a373653f2%3Aamzn1.sym.af2622b9-f19b-41dc-b23f-021a373653f2&crid=334CLJXJECYO9&cv_ct_cx=football%2Bgame&keywords=football%2Bgame&pd_rd_i=B0DGFW36YX&pd_rd_r=cc8f2030-5884-4897-8611-644aa300c6b9&pd_rd_w=0usRs&pd_rd_wg=3jVPb&pf_rd_p=af2622b9-f19b-41dc-b23f-021a373653f2&pf_rd_r=G35GZ28DDVBRNGZJT4KW&qid=1758215960&sbo=RZvfv%2F%2FHxDF%2BO5021pAnSA%3D%3D&sprefix=football%2Bgame%2Caps%2C157&sr=1-2-7efdef4d-9875-47e1-927f-8c2c1c47ed49-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9zZWFyY2hfdGhlbWF0aWM&th=1#:~:text=https%3A//amzn.to/4881Mcj",
+    fallbackTitle: "Football Board Game for Kids",
     tagline:
-      "Brick a tabletop football match and run your own belt defenses at home.",
-    cta: "Kick off the LEGO build →",
+      "Football Board Game for Kids",
+    cta: "Football Board Game for Kids →",
   },
 ];
 

--- a/data/amazonProducts.js
+++ b/data/amazonProducts.js
@@ -15,12 +15,10 @@ const amazonProducts = [
     cta: "Grab the Canes necklace →",
   },
   {
-    link: "https://amzn.to/3K9vyDt",
-    fallbackTitle: "YouTheFan NCAA Team Spirit Coasters",
-    fallbackImage: "/images/sport-fan-coasters.svg",
-    tagline:
-      "Set out these layered team coasters to keep your tailgate surfaces spotless.",
-    cta: "Dress up the drink table →",
+    link: "https://amzn.to/3KfWkKh",
+    fallbackTitle: "Zep-Pro NCAA Florida Gators Belt",
+    tagline: "Lock in gameday outfits with this leather belt stamped for the Gators.",
+    cta: "Strap on the Gators belt →",
   },
   {
     asin: "B07QYCVT29",
@@ -31,17 +29,21 @@ const amazonProducts = [
     cta: "Crown your champion →",
   },
   {
-    link: "https://amzn.to/48jxLpO",
-    fallbackTitle: "Fan Cave Must-Have",
-    tagline: "Give your watch party a fresh focal point with this Amazon find.",
-    cta: "Upgrade your fan cave →",
+    asin: "B07TTFJGJC",
+    link: "https://www.amazon.com/YouTheFan-Spirit-Coasters-Florida-Gators/dp/B07TTFJGJC?tag=cfbbelt-20&linkCode=ll1&language=en_US&ref_=as_li_ss_tl",
+    fallbackTitle: "YouTheFan NCAA Team Spirit Coasters",
+    fallbackImage: "/images/sport-fan-coasters.svg",
+    tagline:
+      "Set out these layered team coasters to keep your tailgate surfaces spotless.",
+    cta: "Dress up the drink table →",
   },
   {
-    link: "https://amzn.to/4mjjkW3",
-    fallbackTitle: "Weekly Amazon Spotlight",
+    asin: "B0B7QPYZVP",
+    link: "https://www.amazon.com/LEGO-Ideas-Table-Football-Building/dp/B0B7QPYZVP?tag=cfbbelt-20&linkCode=ll1&language=en_US&ref_=as_li_ss_tl",
+    fallbackTitle: "LEGO Ideas Table Football (21337)",
     tagline:
-      "See what caught our eye around the belt this week and snag it before it's gone.",
-    cta: "See the full details →",
+      "Brick a tabletop football match and run your own belt defenses at home.",
+    cta: "Kick off the LEGO build →",
   },
 ];
 

--- a/styles/FullWidthAd.module.css
+++ b/styles/FullWidthAd.module.css
@@ -1,6 +1,13 @@
 .fullWidthAd {
-  width: 100%;
-  margin: 0 0 1rem;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  width: 100vw;
+  max-width: none;
+  margin: 0;
+  margin-left: -50vw;
+  margin-right: -50vw;
+  margin-bottom: 1rem;
   padding: 0;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- restore the Zep-Pro belt card in the third Amazon banner slot and update the copy
- move the Florida Gators coaster card into the former fan cave position
- feature the LEGO Ideas Table Football set in place of the weekly Amazon spotlight card

## Testing
- npm run lint *(fails: Next.js prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2bf1dbcc8332816f77b51d659543