### PR TITLE
Handle missing Amazon credentials gracefully

### DIFF
--- a/pages/api/amazon-ads.js
+++ b/pages/api/amazon-ads.js
@@ -1,4 +1,4 @@
-import { getItems, searchItems } from "../../utils/amazon.js";
+import { getCredentials, getItems, searchItems } from "../../utils/amazon.js";
 
 const asinPattern = /^[A-Z0-9]{10}$/;
 
@@ -210,12 +210,18 @@ export default async function handler(req, res) {
   }
 
   try {
+    const credentials = getCredentials();
+    if (!credentials) {
+      res.status(200).json({ items: [] });
+      return;
+    }
+
     if (products.length === 0) {
       const fallbackKeywords =
         typeof keywords === "string" && keywords.trim().length > 0
           ? keywords
           : "college football gear";
-      const data = await searchItems(fallbackKeywords);
+      const data = await searchItems(fallbackKeywords, credentials);
       if (Array.isArray(data?.Errors) && data.Errors.length > 0) {
         const errorMessage = data.Errors.map((error) => error.Message || error.Code)
           .filter(Boolean)
@@ -245,7 +251,7 @@ export default async function handler(req, res) {
 
     let detailsByAsin = new Map();
     if (uniqueAsins.length > 0) {
-      const data = await getItems(uniqueAsins);
+      const data = await getItems(uniqueAsins, credentials);
       if (Array.isArray(data?.Errors) && data.Errors.length > 0) {
         const errorMessage = data.Errors.map((error) => error.Message || error.Code)
           .filter(Boolean)

--- a/tests/amazon-ads.test.mjs
+++ b/tests/amazon-ads.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import handler from '../pages/api/amazon-ads.js';
+
+function createMockRes() {
+  return {
+    statusCode: undefined,
+    jsonData: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data) {
+      this.jsonData = data;
+      return this;
+    },
+  };
+}
+
+test('returns empty items when Amazon credentials are missing', async () => {
+  const keys = [
+    'AMAZON_ACCESS_KEY',
+    'AMAZON_SECRET_KEY',
+    'AMAZON_ASSOCIATE_TAG',
+  ];
+  const original = {};
+  for (const key of keys) {
+    original[key] = process.env[key];
+    delete process.env[key];
+  }
+
+  const req = { method: 'GET', query: {} };
+  const res = createMockRes();
+
+  try {
+    await handler(req, res);
+  } finally {
+    for (const key of keys) {
+      const value = original[key];
+      if (typeof value === 'string') {
+        process.env[key] = value;
+      } else {
+        delete process.env[key];
+      }
+    }
+  }
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.jsonData, { items: [] });
+});


### PR DESCRIPTION
## Summary
- return `null` from the Amazon credential helpers when configuration is missing and reuse existing credentials for API calls
- short-circuit the Amazon ads API handler so requests fall back to empty results when credentials are absent
- add a node:test case ensuring the handler responds with a 200/empty payload without Amazon credentials

## Testing
- node --test tests/amazon-ads.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cc5b2016848332b69555d141ee778c