### PR TITLE
Improve SEO metadata and sitemap generation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/components/Seo.js
+++ b/components/Seo.js
@@ -1,0 +1,89 @@
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+
+export const SITE_URL = 'https://collegefootballbelt.com';
+export const SITE_NAME = 'College Football Belt';
+const DEFAULT_TITLE = `${SITE_NAME} – The Lineal College Football Championship Tracker`;
+const DEFAULT_DESCRIPTION =
+  'Track the College Football Belt, follow upcoming matchups, and dive into the full history of the sport\'s lineal championship.';
+const DEFAULT_IMAGE = '/images/fallback-helmet.png';
+
+const toAbsoluteUrl = (value) => {
+  if (!value) return `${SITE_URL}${DEFAULT_IMAGE}`;
+  if (value.startsWith('http://') || value.startsWith('https://')) return value;
+  if (value.startsWith('/')) return `${SITE_URL}${value}`;
+  return `${SITE_URL}/${value}`;
+};
+
+const sanitizePath = (value) => {
+  if (!value) return '/';
+  const path = value.startsWith(SITE_URL)
+    ? value.replace(SITE_URL, '')
+    : value;
+  const withoutHash = path.split('#')[0];
+  const withoutQuery = withoutHash.split('?')[0];
+  if (!withoutQuery) return '/';
+  return withoutQuery.startsWith('/') ? withoutQuery : `/${withoutQuery}`;
+};
+
+const formatTitle = (title) => {
+  if (!title) return DEFAULT_TITLE;
+  const normalized = title.toLowerCase();
+  return normalized.includes(SITE_NAME.toLowerCase())
+    ? title
+    : `${title} | ${SITE_NAME}`;
+};
+
+const serializeStructuredData = (data) => {
+  if (!data) return null;
+  try {
+    return JSON.stringify(data).replace(/</g, '\\u003c');
+  } catch (error) {
+    console.warn('Unable to serialize structured data for SEO', error);
+    return null;
+  }
+};
+
+export default function Seo({
+  title,
+  description = DEFAULT_DESCRIPTION,
+  canonicalPath,
+  image = DEFAULT_IMAGE,
+  type = 'website',
+  noIndex = false,
+  structuredData,
+}) {
+  const router = useRouter();
+  const path = canonicalPath ?? router?.asPath ?? '/';
+  const canonical = `${SITE_URL}${sanitizePath(path)}`;
+  const formattedTitle = formatTitle(title);
+  const absoluteImage = toAbsoluteUrl(image);
+  const robotsContent = noIndex ? 'noindex, nofollow' : 'index, follow';
+  const structuredDataJson = serializeStructuredData(structuredData);
+
+  return (
+    <Head>
+      <title>{formattedTitle}</title>
+      <meta name="description" content={description} />
+      <meta property="og:title" content={formattedTitle} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={absoluteImage} />
+      <meta property="og:url" content={canonical} />
+      <meta property="og:site_name" content={SITE_NAME} />
+      <meta property="og:type" content={type} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={formattedTitle} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={absoluteImage} />
+      <link rel="canonical" href={canonical} />
+      <meta name="robots" content={robotsContent} />
+      {structuredDataJson ? (
+        <script
+          key="structured-data"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: structuredDataJson }}
+        />
+      ) : null}
+    </Head>
+  );
+}

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,68 @@
+const { readFileSync } = require('fs');
+const path = require('path');
+const { parse } = require('csv-parse/sync');
+
+const SITE_URL = 'https://collegefootballbelt.com';
+
+const extractOpponent = (value) => {
+  if (!value) return null;
+  const match = value.match(/^(vs\.?|at)\s+(?:#\d+\s+)?(.*?)\s+\((?:W|L|T)\s+\d+[\-–]\d+\)/i);
+  return match ? match[2].trim() : null;
+};
+
+const collectTeamPaths = () => {
+  try {
+    const csvPath = path.join(__dirname, 'data', 'belt-history.csv');
+    const raw = readFileSync(csvPath, 'utf8');
+    const records = parse(raw, { columns: true, skip_empty_lines: true });
+    const teams = new Set();
+
+    records.forEach((record) => {
+      const holder = (record.BeltHolder || '').trim();
+      if (holder) teams.add(holder);
+
+      const challenger = extractOpponent(record.BeltWon);
+      if (challenger) teams.add(challenger);
+
+      Object.keys(record)
+        .filter((key) => key.toLowerCase().startsWith('defense'))
+        .forEach((key) => {
+          const opponent = extractOpponent(record[key]);
+          if (opponent) teams.add(opponent);
+        });
+    });
+
+    return Array.from(teams)
+      .filter(Boolean)
+      .map((team) => `/team/${encodeURIComponent(team)}`)
+      .sort();
+  } catch (error) {
+    console.warn('next-sitemap: unable to parse belt-history.csv', error);
+    return [];
+  }
+};
+
+module.exports = {
+  siteUrl: SITE_URL,
+  generateRobotsTxt: false,
+  ignoreBuildManifest: true,
+  exclude: ['/api/*', '/404', '/500'],
+  changefreq: 'weekly',
+  priority: 0.7,
+  transform: async (config, path) => ({
+    loc: path,
+    changefreq: path === '/' ? 'daily' : config.changefreq,
+    priority: path === '/' ? 1.0 : config.priority,
+    lastmod: new Date().toISOString(),
+  }),
+  additionalPaths: async (config) => {
+    const teamPaths = collectTeamPaths();
+    const lastmod = new Date().toISOString();
+    return teamPaths.map((loc) => ({
+      loc,
+      changefreq: 'weekly',
+      priority: 0.6,
+      lastmod,
+    }));
+  },
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "sitemap": "next-sitemap",
+    "postbuild": "next-sitemap"
   },
   "dependencies": {
     "csv-parse": "^5.6.0",

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,21 +1,29 @@
 import React from 'react';
 import NavBar from '../components/NavBar';
-import Head from 'next/head';
 import AdSlot from '../components/AdSlot';
 import adStyles from '../styles/FullWidthAd.module.css';
+import Seo, { SITE_URL } from '../components/Seo';
 
 export default function AboutPage() {
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'AboutPage',
+    name: 'About the College Football Belt',
+    url: `${SITE_URL}/about`,
+    description:
+      'Background on the College Football Belt project, its mission, and how fans can support the site.',
+  };
+
   return (
     <>
+      <Seo
+        title="About"
+        description="Learn about the College Football Belt project, its history, and how to support the site."
+        canonicalPath="/about"
+        structuredData={structuredData}
+      />
       <NavBar />
       <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
-        <Head>
-          <title>About - College Football Belt</title>
-          <meta
-            name="description"
-            content="Learn about the College Football Belt project, its history, and how to support the site."
-          />
-        </Head>
 
         <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>About the College Football Belt</h1>
 

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -1,17 +1,27 @@
 // pages/blog.js
 import NavBar from '../components/NavBar';
-import Head from 'next/head';
+import Seo, { SITE_URL } from '../components/Seo';
 
 export default function Blog() {
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'Blog',
+    name: 'College Football Belt Blog',
+    url: `${SITE_URL}/blog`,
+    description: 'Latest stories, analysis, and history notes from the College Football Belt.',
+  };
+
   return (
     <>
+      <Seo
+        title="Blog"
+        description="Follow the latest updates and insights about the College Football Belt."
+        canonicalPath="/blog"
+        image="/images/2025week1.png"
+        structuredData={structuredData}
+      />
       <NavBar />
       <div style={{ maxWidth: '800px', margin: '0 auto', padding: '1rem' }}>
-        <Head>
-          <title>CFB Belt Blog</title>
-          <meta name="description" content="Follow the latest updates and insights about the College Football Belt." />
-          <meta property="og:image" content="/images/2025week1.png" />
-        </Head>
 
         <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>College Football Belt Blog</h1>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import NavBar from '../components/NavBar';
 import { teamLogoMap, normalizeTeamName, computeRecord } from '../utils/teamUtils';
-import Head from 'next/head';
 import AdSlot from '../components/AdSlot';
 import NewsletterSignup from '../components/NewsletterSignup';
 import BeltBookBanner from '../components/BeltBookBanner';
@@ -11,6 +10,7 @@ import { beltBookSpotlight } from '../data/beltBookSpotlight';
 import { fetchFromApi } from '../utils/ssr';
 import homeStyles from '../styles/HomePage.module.css';
 import adStyles from '../styles/FullWidthAd.module.css';
+import Seo, { SITE_NAME, SITE_URL } from '../components/Seo';
 
 // ...inside your component render where the placeholder was:
 
@@ -33,10 +33,36 @@ export default function HomePage({ data }) {
   const page = parseInt(router.query.page || '1', 10);
   const itemsPerPage = 10;
   const nextOpponent = 'Florida';
+  const homepageStructuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: SITE_NAME,
+    url: SITE_URL,
+    description:
+      'Live tracker for the College Football Belt, the lineal championship that passes whenever the reigning holder is defeated.',
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: `${SITE_URL}/team/{search_term_string}`,
+      'query-input': 'required name=search_term_string',
+    },
+    about: {
+      '@type': 'Thing',
+      name: 'College Football Belt',
+      description:
+        'College football’s unofficial lineal championship traced from 1869 to the present day.',
+    },
+  };
 
   if (!data.length) {
     return (
       <>
+        <Seo
+          title="College Football Belt – The Lineal Title Tracker"
+          description="Track the history, reigns, and future path of the College Football Belt – the lineal championship of college football."
+          canonicalPath="/"
+          image="/images/fallback-helmet.png"
+          structuredData={homepageStructuredData}
+        />
         <NavBar />
         <div
           style={{
@@ -122,19 +148,14 @@ export default function HomePage({ data }) {
 
   return (
     <>
+      <Seo
+        title="College Football Belt – The Lineal Title Tracker"
+        description="Track the history, reigns, and future path of the College Football Belt – the lineal championship of college football."
+        canonicalPath="/"
+        image="/images/fallback-helmet.png"
+        structuredData={homepageStructuredData}
+      />
       <NavBar />
-      <Head>
-        <title>College Football Belt – The Lineal Title Tracker</title>
-        <meta
-          name="description"
-          content="Track the history, reigns, and future path of the College Football Belt – the lineal championship of college football."
-        />
-        <meta property="og:title" content="College Football Belt – CFB Lineal Championship" />
-        <meta property="og:description" content="See which team holds the College Football Belt, explore historical reigns, and follow its potential path." />
-        <meta property="og:image" content="/images/fallback-helmet.png" />
-        <meta property="og:url" content="https://your-domain.com" />
-        <meta name="twitter:card" content="summary_large_image" />
-      </Head>
       <div className={homeStyles.pageContainer}>
         <div className={`${adStyles.fullWidthAd} ${adStyles.tightTop}`}>
           <div className={adStyles.inner}>

--- a/pages/path-to-conference.js
+++ b/pages/path-to-conference.js
@@ -1,19 +1,27 @@
 import React from 'react';
 import NavBar from '../components/NavBar';
-import Head from 'next/head';
+import Seo, { SITE_URL } from '../components/Seo';
 
 export default function PathToConference() {
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    name: 'Path to the Conferences',
+    url: `${SITE_URL}/path-to-conference`,
+    description:
+      'Projected scenarios showing how the College Football Belt could travel between conferences during the 2025 season.',
+  };
+
   return (
     <>
+      <Seo
+        title="Path to the Conferences"
+        description="See how the College Football Belt could move into each conference during the 2025 season."
+        canonicalPath="/path-to-conference"
+        structuredData={structuredData}
+      />
       <NavBar />
       <div style={{ maxWidth: '900px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
-        <Head>
-          <title>Path to the Conferences - College Football Belt</title>
-          <meta
-            name="description"
-            content="See how the College Football Belt could move into each conference during the 2025 season."
-          />
-        </Head>
         <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Path to the Conferences</h1>
 
       <p style={{ fontSize: '1rem', marginBottom: '1rem' }}>

--- a/pages/record-book.js
+++ b/pages/record-book.js
@@ -2,29 +2,36 @@ import React from 'react';
 import NavBar from '../components/NavBar';
 import AdSlot from '../components/AdSlot';
 import adStyles from '../styles/FullWidthAd.module.css';
-import Head from 'next/head';
+import Seo, { SITE_URL } from '../components/Seo';
 import Link from 'next/link';
 import { teamLogoMap, normalizeTeamName } from '../utils/teamUtils';
 import { fetchFromApi } from '../utils/ssr';
 
 export default function RecordBookPage({ data }) {
-  const head = (
-    <Head>
-      <title>Record Book - College Football Belt</title>
-      <meta
-        name="description"
-        content="Historical highlights and statistical leaders from every College Football Belt game."
-      />
-      <meta property="og:image" content="/images/fallback-helmet.png" />
-    </Head>
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: 'College Football Belt Record Book',
+    url: `${SITE_URL}/record-book`,
+    description:
+      'Historical highlights and statistical leaders from every College Football Belt game.',
+  };
+
+  const seo = (
+    <Seo
+      title="Record Book"
+      description="Historical highlights and statistical leaders from every College Football Belt game."
+      canonicalPath="/record-book"
+      structuredData={structuredData}
+    />
   );
 
   if (!data.length)
     return (
       <>
+        {seo}
         <NavBar />
         <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
-          {head}
           <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Record Book</h1>
           <p style={{ marginBottom: '1rem' }}>
             Historical highlights and statistical leaders from every College Football Belt game.
@@ -102,10 +109,9 @@ export default function RecordBookPage({ data }) {
 
   return (
     <>
+      {seo}
       <NavBar />
       <div style={{ maxWidth: '800px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
-        {head}
-
         {/* Safe top ad: only after data is present */}
         <div className={`${adStyles.fullWidthAd} ${adStyles.tightTop}`}>
           <div className={adStyles.inner}>

--- a/pages/team/[team].js
+++ b/pages/team/[team].js
@@ -8,7 +8,7 @@ import {
 import AdSlot from '../../components/AdSlot';
 import adStyles from '../../styles/FullWidthAd.module.css';
 import NavBar from '../../components/NavBar';
-import Head from 'next/head';
+import Seo, { SITE_URL } from '../../components/Seo';
 import { fetchFromApi } from '../../utils/ssr';
 
 const styles = {
@@ -27,20 +27,7 @@ const styles = {
 
 export default function TeamPage({ data, team }) {
   const [expandedRows, setExpandedRows] = useState({});
-  const defaultHead = (
-    <Head>
-      <title>{team ? `${team} - College Football Belt History` : 'College Football Belt Team'}</title>
-      <meta
-        name="description"
-        content={
-          team
-            ? `Explore ${team}'s history with the College Football Belt.`
-            : 'Team information for the College Football Belt.'
-        }
-      />
-      <meta property="og:image" content="/images/fallback-helmet.png" />
-    </Head>
-  );
+  const canonicalPath = team ? `/team/${encodeURIComponent(team)}` : '/team';
 
   useEffect(() => {
     if (typeof window !== 'undefined' && team) {
@@ -51,6 +38,16 @@ export default function TeamPage({ data, team }) {
   if (!data.length || !team) {
     return (
       <>
+        <Seo
+          title={team ? `${team} - College Football Belt History` : 'College Football Belt Team'}
+          description={
+            team
+              ? `Explore ${team}'s history with the College Football Belt.`
+              : 'Team information for the College Football Belt.'
+          }
+          canonicalPath={canonicalPath}
+          noIndex
+        />
         <NavBar />
         <div
           style={{
@@ -61,7 +58,6 @@ export default function TeamPage({ data, team }) {
             textAlign: 'center',
           }}
         >
-          {defaultHead}
           <p style={{ marginTop: '2rem' }}>No data available.</p>
           <p>Please check back later.</p>
         </div>
@@ -91,6 +87,16 @@ export default function TeamPage({ data, team }) {
     // 🚫 No ads here, just a message
     return (
       <>
+        <Seo
+          title={team ? `${team} - College Football Belt History` : 'College Football Belt Team'}
+          description={
+            team
+              ? `Explore ${team}'s history with the College Football Belt.`
+              : 'Team information for the College Football Belt.'
+          }
+          canonicalPath={canonicalPath}
+          noIndex
+        />
         <NavBar />
         <div
           style={{
@@ -104,7 +110,6 @@ export default function TeamPage({ data, team }) {
             textAlign: 'center',
           }}
         >
-          {defaultHead}
           <h1 style={{ fontSize: '2rem', color: '#001f3f', marginTop: '1rem' }}>
             Team not found
           </h1>
@@ -122,16 +127,15 @@ export default function TeamPage({ data, team }) {
     ? `https://a.espncdn.com/i/teamlogos/ncaa/500/${logoId}.png`
     : '';
 
-  const head = (
-    <Head>
-      <title>{team} - College Football Belt History</title>
-      <meta
-        name="description"
-        content={`Explore ${team}'s history with the College Football Belt.`}
-      />
-      <meta property="og:image" content={logoUrl || '/images/fallback-helmet.png'} />
-    </Head>
-  );
+  const teamStructuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'SportsTeam',
+    name: team,
+    sport: 'College Football',
+    url: `${SITE_URL}${canonicalPath}`,
+    description: `College Football Belt history for ${team}.`,
+    logo: logoUrl || `${SITE_URL}/images/fallback-helmet.png`,
+  };
 
   const filteredReigns = data
     .filter((r) => normalizeTeamName(r.beltHolder) === normalizedTeam)
@@ -204,6 +208,13 @@ export default function TeamPage({ data, team }) {
 
   return (
     <>
+      <Seo
+        title={`${team} - College Football Belt History`}
+        description={`Explore ${team}'s history with the College Football Belt.`}
+        canonicalPath={canonicalPath}
+        image={logoUrl || '/images/fallback-helmet.png'}
+        structuredData={teamStructuredData}
+      />
       <NavBar />
       <div
         style={{
@@ -217,8 +228,6 @@ export default function TeamPage({ data, team }) {
           borderRadius: '8px',
         }}
       >
-        {head}
-
         {/* ✅ Gate manual ads on real data */}
         <div className={adStyles.fullWidthAd}>
           <div className={adStyles.inner}>

--- a/pages/team/allteamsrecords.js
+++ b/pages/team/allteamsrecords.js
@@ -4,7 +4,7 @@ import { teamLogoMap, normalizeTeamName, computeRecord } from '../../utils/teamU
 import NavBar from '../../components/NavBar';
 import AdSlot from '../../components/AdSlot';
 import adStyles from '../../styles/FullWidthAd.module.css';
-import Head from 'next/head';
+import Seo, { SITE_URL } from '../../components/Seo';
 import { fetchFromApi } from '../../utils/ssr';
 
 const cleanTeamName = (name = '') =>
@@ -39,20 +39,28 @@ export default function AllTeamsRecords({ data }) {
   const [sortKey, setSortKey] = useState('wins');
   const [sortAsc, setSortAsc] = useState(false);
 
-  const head = (
-    <Head>
-      <title>All Teams Records - College Football Belt</title>
-      <meta
-        name="description"
-        content="Search and sort every program's performance in College Football Belt history."
-      />
-      <meta property="og:image" content="/images/fallback-helmet.png" />
-    </Head>
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'Dataset',
+    name: 'College Football Belt – All Teams Records',
+    url: `${SITE_URL}/team/allteamsrecords`,
+    description:
+      "Sortable records showing every program's wins, losses, ties, and reigns in College Football Belt history.",
+  };
+
+  const seo = (
+    <Seo
+      title="All Teams Records"
+      description="Search and sort every program's performance in College Football Belt history."
+      canonicalPath="/team/allteamsrecords"
+      structuredData={structuredData}
+    />
   );
 
   if (!data.length) {
     return (
       <>
+        {seo}
         <NavBar />
         <div
           style={{
@@ -63,7 +71,6 @@ export default function AllTeamsRecords({ data }) {
             textAlign: 'center',
           }}
         >
-          {head}
           <p style={{ marginTop: '2rem' }}>No data available.</p>
           <p>Try again later.</p>
         </div>
@@ -115,10 +122,9 @@ export default function AllTeamsRecords({ data }) {
 
   return (
     <>
+      {seo}
       <NavBar />
       <div style={{ maxWidth: '1000px', margin: '0 auto', padding: '1rem' }}>
-        {head}
-
         <div className={`${adStyles.fullWidthAd} ${adStyles.spaced}`}>
           <div className={adStyles.inner}>
             <AdSlot

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,5 @@ User-agent: *
 Allow: /ads.txt
 Disallow:
 
+Sitemap: https://collegefootballbelt.com/sitemap.xml
+


### PR DESCRIPTION
## Summary
- add a reusable `<Seo>` helper that centralizes canonical URLs, social meta tags, and JSON-LD schema support
- migrate the homepage, content, and team detail pages to the new helper with tailored descriptions and structured data
- configure sitemap generation, expose the sitemap location in robots.txt, and add a baseline ESLint config for repeatable lint runs

## Testing
- npm run lint *(fails: eslint is not installed in the execution environment and npm install is blocked by registry restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cdae110bbc83328a4fe5625788a62d