### PR TITLE
Update belt tracker for Miami's Florida win and FSU matchup

### DIFF
--- a/data/amazonProducts.js
+++ b/data/amazonProducts.js
@@ -1,11 +1,11 @@
 const amazonProducts = [
   {
-    asin: "B0D8KTKMQW",
-    link: "https://www.amazon.com/PILOYINDE-Basketball-gators-Bedroom-Florida/dp/B0D8KTKMQW?crid=AHXD6SCISDXA&dib=eyJ2IjoiMSJ9.pk6LKRJrWyC7tifXE2tQbN2UHnVHAwrlI4IPwD53yX2X4rStgfTuv1E_gHFBJRWrYYNyzek8UgroFTHJ2qfBC9oFmhWiy6wCjPYdM_XIc9ixmGdf9mpDyNYY6kFC2lvq9Q-RouPS3N-7afPhlf5A8xbgqwmjs6dGSCNuwfl6LoHCn4NcQk-KFNeveGhubv6-mgtvtFedK9ZOKUEb78pPxg-PyAS1yWzmtKb2Cgn0K0PxHLRP3ELlvTId2RxRFpUWmn2XddGhIf56XIk9eMrKX-Nzb6rvOrDJpD8Tt9d6Ncw.c6dWX31Ia5o_cu0xK9xQRP160sau0_kFYXJ94CuoEl4&dib_tag=se&keywords=florida%2Bgators%2Bgear&qid=1758030266&sprefix=florida%2Bgators%2Bgrea%2Caps%2C196&sr=8-2-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&th=1&linkCode=ll1&tag=cfbbelt-20&linkId=038c37e92c6cfc6ad877d0ab0bbdf5d0&language=en_US&ref_=as_li_ss_tl",
-    fallbackTitle: "Florida Gators Wall Art",
+    asin: "B00KAQBZQQ",
+    link: "https://www.amazon.com/Florida-State-Seminoles-2-Sided-Flag/dp/B00KAQBZQQ?tag=cfbbelt-20&linkCode=ll1&language=en_US&ref_=as_li_ss_tl",
+    fallbackTitle: "Florida State Seminoles Garden Flag",
     tagline:
-      "Turn your fan cave into the Swamp with this bold Gators wall print.",
-    cta: "Shop Florida gear →",
+      "Fly garnet and gold outside your tailgate spot before the showdown in Tallahassee.",
+    cta: "Shop Florida State gear →",
   },
   {
     asin: "B00W5VNB80",

--- a/data/belt-history.csv
+++ b/data/belt-history.csv
@@ -1,5 +1,5 @@
 Overall Reign #,BeltHolder,TeamReign,StartofReign,EndofReign,# of Defenses,BeltWon,Defense 1,Defense 2,Defense 3,Defense 4,Defense 5,Defense 6,Defense 7,Defense 8,Defense 9,Defense 10,Defense 11,Defense 12,Defense 13,Defense 14,Defense 15,Defense 16,Defense 17,Defense 18,Defense 19,Defense 20,Defense 21,Defense 22,Defense 23,Defense 24,Defense 25,Defense 26,Defense 27,Defense 28,Defense 29,Defense 30,Defense 31,Defense 32,Defense 33,Defense 34,Defense 35,Defense 36,Defense 37
-332,Miami,6,09/13/2025,Ongoing,0,vs. South Florida (W 49–12),vs. Florida,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+332,Miami,6,09/13/2025,Ongoing,1,vs. South Florida (W 49–12),vs. Florida (W 26–7),at Florida State (10/04, 7:00 PM ET),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 331,South Florida,1,09/06/2025,09/13/2025,0,at Florida (W 18–16),at Miami (L 49–12),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 330,Florida,6,11/23/2024,09/06/2025,3,vs. #9 Ole Miss (W 24–14),at Florida State (W 31–11),vs. Tulane (Gasparilla Bowl) (W 33–8),vs. LIU (W 55-0),vs. South Florida (L 18-16),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 329,Ole Miss,6,11/10/2024,11/23/2024,0,vs. Georgia (W 28–10),at Florida (L 24–14),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,

--- a/data/beltBookSpotlight.js
+++ b/data/beltBookSpotlight.js
@@ -1,6 +1,6 @@
 export const beltBookSpotlight = {
   title: "Belt Book of the Week",
-  subtitle: "Miami vs. Florida Matchup Picks",
+  subtitle: "Miami at Florida State Matchup Picks",
   books: [
     {
       title: "Cane Mutiny: How the Miami Hurricanes Overturned the Football Establishment",
@@ -13,14 +13,14 @@ export const beltBookSpotlight = {
       badgeTextColor: "#ffffff",
     },
     {
-      title: "The Boys from Old Florida: Inside the Gators' Greatest Teams",
-      author: "Buddy Martin",
-      team: "Florida Gators",
-      link: "https://www.amazon.com/Boys-Old-Florida-Gators-Greatest/dp/0345509595?tag=cfbbelt-20&linkCode=ll1&language=en_US&ref_=as_li_ss_tl",
-      image: "https://m.media-amazon.com/images/P/0345509595.01._SCLZZZZZZZ_.jpg",
-      imageAlt: "Cover of The Boys from Old Florida by Buddy Martin",
-      badgeColor: "#0021A5",
-      badgeTextColor: "#f8fafc",
+      title: "Seminoles!: The First 50 Years of Florida State Football",
+      author: "Bill McGrotha",
+      team: "Florida State Seminoles",
+      link: "https://www.amazon.com/Seminoles-First-Florida-State-Football/dp/1561643315?tag=cfbbelt-20&linkCode=ll1&language=en_US&ref_=as_li_ss_tl",
+      image: "https://m.media-amazon.com/images/P/1561643315.01._SCLZZZZZZZ_.jpg",
+      imageAlt: "Cover of Seminoles!: The First 50 Years of Florida State Football by Bill McGrotha",
+      badgeColor: "#782F40",
+      badgeTextColor: "#CEB888",
     },
   ],
 };

--- a/pages/index.js
+++ b/pages/index.js
@@ -32,7 +32,7 @@ export default function HomePage({ data }) {
   const router = useRouter();
   const page = parseInt(router.query.page || '1', 10);
   const itemsPerPage = 10;
-  const nextOpponent = 'Florida';
+  const nextOpponent = 'Florida State';
   const homepageStructuredData = {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
@@ -219,7 +219,7 @@ export default function HomePage({ data }) {
               <section className={homeStyles.section}>
                 <h2 className={homeStyles.sectionTitle}>Next Game Preview</h2>
                 <p className={homeStyles.bodyText}>
-                  Miami seized the College Football Belt with a commanding 49–12 home win over South Florida. The Hurricanes now prepare for their first defense as they host the Florida Gators in a heated in-state clash. Florida entered the season with the belt, lost it to USF, and already has a chance to win it back one week later.
+                  Miami throttled Florida 26–7 to post its first defense since reclaiming the College Football Belt from South Florida. Next up is a prime-time trip to Tallahassee on October 4 at 7 p.m. ET, where rival Florida State will try to rip the belt away on its home field.
                 </p>
               </section>
 

--- a/pages/path-to-conference.js
+++ b/pages/path-to-conference.js
@@ -25,18 +25,19 @@ export default function PathToConference() {
         <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Path to the Conferences</h1>
 
       <p style={{ fontSize: '1rem', marginBottom: '1rem' }}>
-        This page tracks the most likely way the belt could end up in each major conference during the 2025 season, based on Florida's current possession of the belt and their schedule. Bowl games and playoffs are not included.
+        This page tracks the most likely way the belt could end up in each major conference during the 2025 season, based on Miami's current possession of the belt and the remaining schedule. Bowl games and playoffs are not included.
       </p>
 
       <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>ACC</h2>
       <ol>
-        <li>South Florida loses to <strong>Miami</strong> (Week 3)</li>
-    
+        <li><strong>Completed:</strong> South Florida lost to Miami (Week 3).</li>
+        <li><strong>Completed:</strong> Miami defended the belt by beating Florida 26–7 (Week 4).</li>
+        <li><strong>Next:</strong> Miami travels to Florida State on October 4 for a 7 p.m. ET kickoff.</li>
       </ol>
 
           <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>SEC</h2>
       <p style={{ marginBottom: '0.5rem' }}>
-        USF loses to Miami, who loses to Florida to give it back them for a second time this season.
+        Florida's quick turnaround bid fizzled in Miami. For the belt to return to the SEC, the Seminoles would need to capture it and then fall to Florida or another SEC opponent later in the fall.
       </p>
 
       <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>Big 12</h2>
@@ -51,7 +52,7 @@ export default function PathToConference() {
 
       <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>Group of Five / Independents</h2>
       <p style={{ marginBottom: '0.5rem' }}>
-        The belt is currently in the AAC.
+        The belt now resides in the ACC.
       </p>
 
         <div style={{ marginTop: '2rem', fontStyle: 'italic', color: '#444' }}>


### PR DESCRIPTION
## Summary
- record Miami's 26-7 victory over Florida in the belt history and upcoming Florida State defense details
- refresh homepage, book spotlight, and marketing copy to highlight the rivalry trip to Tallahassee
- update conference path page to reflect Miami's possession and revised ACC/SEC outlook

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d02f3f6278833284eed76bdf0e2e78