### PR TITLE
Fix last-updated API to avoid git dependency

### DIFF
--- a/pages/api/last-updated.js
+++ b/pages/api/last-updated.js
@@ -1,13 +1,14 @@
-import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
   try {
-    const date = execSync('git log -1 --format=%cI', {
-      encoding: 'utf-8',
-      cwd: process.cwd(),
-    }).trim();
-    res.status(200).json({ lastUpdated: date });
+    const dataDir = path.join(process.cwd(), 'data');
+    const beltHistoryPath = path.join(dataDir, 'belt-history.csv');
+    const stat = await fs.promises.stat(beltHistoryPath);
+    res.status(200).json({ lastUpdated: stat.mtime.toISOString() });
   } catch (err) {
+    console.error('Failed to determine last updated time', err);
     res.status(500).json({ error: 'Unable to determine last updated time' });
   }
 }


### PR DESCRIPTION
## Summary
- replace the git-based last updated lookup with filesystem metadata that is available in serverless deployments
- add error logging before returning a failure response

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d03414e7ec83329a46a8556f9c57a4