### PR TITLE
Fix belt history CSV formatting for Miami entry

### DIFF
--- a/data/belt-history.csv
+++ b/data/belt-history.csv
@@ -1,5 +1,5 @@
 Overall Reign #,BeltHolder,TeamReign,StartofReign,EndofReign,# of Defenses,BeltWon,Defense 1,Defense 2,Defense 3,Defense 4,Defense 5,Defense 6,Defense 7,Defense 8,Defense 9,Defense 10,Defense 11,Defense 12,Defense 13,Defense 14,Defense 15,Defense 16,Defense 17,Defense 18,Defense 19,Defense 20,Defense 21,Defense 22,Defense 23,Defense 24,Defense 25,Defense 26,Defense 27,Defense 28,Defense 29,Defense 30,Defense 31,Defense 32,Defense 33,Defense 34,Defense 35,Defense 36,Defense 37
-332,Miami,6,09/13/2025,Ongoing,1,vs. South Florida (W 49–12),vs. Florida (W 26–7),at Florida State (10/04, 7:00 PM ET),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+332,Miami,6,09/13/2025,Ongoing,1,vs. South Florida (W 49–12),vs. Florida (W 26–7),at Florida State (10/04 7:00 PM ET),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 331,South Florida,1,09/06/2025,09/13/2025,0,at Florida (W 18–16),at Miami (L 49–12),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 330,Florida,6,11/23/2024,09/06/2025,3,vs. #9 Ole Miss (W 24–14),at Florida State (W 31–11),vs. Tulane (Gasparilla Bowl) (W 33–8),vs. LIU (W 55-0),vs. South Florida (L 18-16),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 329,Ole Miss,6,11/10/2024,11/23/2024,0,vs. Georgia (W 28–10),at Florida (L 24–14),,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
## Summary
- remove the comma inside Miami's upcoming Florida State matchup description so the belt history CSV keeps the expected column structure
- regenerate the row with the correct number of empty defense columns to prevent CSV parsers from throwing errors when reading the file

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0595f14848332905623834fa22c69