### PR TITLE
Update Florida State affiliate products

### DIFF
--- a/data/amazonProducts.js
+++ b/data/amazonProducts.js
@@ -1,11 +1,11 @@
 const amazonProducts = [
   {
-    asin: "B00KAQBZQQ",
-    link: "https://www.amazon.com/Florida-State-Seminoles-2-Sided-Flag/dp/B00KAQBZQQ?tag=cfbbelt-20&linkCode=ll1&language=en_US&ref_=as_li_ss_tl",
-    fallbackTitle: "Florida State Seminoles Garden Flag",
+    asin: "B005QRZ5HK",
+    link: "https://www.amazon.com/Florida-State-Seminoles-Capitol-Decanter/dp/B005QRZ5HK?crid=1ME34R55K7Y6V&dib=eyJ2IjoiMSJ9.-6nyarQ-xLkFTu9pg-g70iBCHra8t6vCBvyIKsTe7AUZ4esIW2iAAO2bploe4yyJ3cKJT4YG6Ia-Z6QMJ2y2ibgiGbPh9TEih17cR9TuuQw.of4VSTFxJbdT4cg-kvVUPoAgevSaZ115A1xdaax20v0&dib_tag=se&keywords=florida%2Bstate%2Bseminoles&qid=1758549055&sprefix=florida%2Bstate%2Caps%2C139&sr=8-50-spons&xpid=Z8l648Z7MRsVl&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGZfbmV4dA&th=1&linkCode=ll1&tag=cfbbelt-20&linkId=3084c0831301e5aab95b51178b694e34&language=en_US&ref_=as_li_ss_tl",
+    fallbackTitle: "Florida State Seminoles Capitol Decanter",
     tagline:
-      "Fly garnet and gold outside your tailgate spot before the showdown in Tallahassee.",
-    cta: "Shop Florida State gear →",
+      "Raise a celebratory pour from a Seminoles decanter shaped like Florida's Capitol dome.",
+    cta: "Toast with the FSU decanter →",
   },
   {
     asin: "B00W5VNB80",
@@ -15,11 +15,12 @@ const amazonProducts = [
     cta: "Grab the Canes necklace →",
   },
   {
-    asin: "B0FC3781XV",
-    link: "https://amzn.to/3KfWkKh",
-    fallbackTitle: "Zep-Pro NCAA Florida Gators Belt",
-    tagline: "Lock in gameday outfits with this leather belt stamped for the Gators.",
-    cta: "Strap on the Gators belt →",
+    asin: "B0DZZ3FJXR",
+    link: "https://www.amazon.com/StadiumSpot-Florida-State-Leather-Mens/dp/B0DZZ3FJXR?crid=FM0SIGWECZGO&dib=eyJ2IjoiMSJ9.DR2s-BdObrgsgjQKEynPxVhFnGpdRsq26ASJrbHyYwA6LA_zxl8kSF8xuoaqzSgipHvU2Co8p9v4Ofsk_G8ygDz4BCewgSGmTh1I8mIuVeNTeJG0NR2_hYU8Yk3kSlzixZ6cIaYqeDzh8hg6nEB5h26Jh6A2G64cQuCsIbuUaXl4nU6fWv7d-OARXHtQoY713bhPvhCPF7S-tHIaaCdo0pMQqkasyAD50pmP2a4ZLY8o-K5tCisbxAoSjJ95i9-fAWudOb9UlbmqGjnuvgmk7QR-9hQFfz-GqLpic_f-jCU.OLOukWov6aLSfVRNYuk4wZUBYmJEyHhmJX2cGJd1L2M&dib_tag=se&keywords=florida+state+belt&qid=1758549103&sprefix=florida+state+belt%2Caps%2C255&sr=8-5&linkCode=ll1&tag=cfbbelt-20&linkId=632d4c82efe3e8732f3df052be3d3c3f&language=en_US&ref_=as_li_ss_tl",
+    fallbackTitle: "StadiumSpot Florida State Leather Men's Belt",
+    tagline:
+      "Finish your Seminoles look with a leather belt that keeps garnet and gold front and center.",
+    cta: "Buckle the FSU belt →",
   },
   {
     asin: "B07QYCVT29",
@@ -30,13 +31,13 @@ const amazonProducts = [
     cta: "Crown your champion →",
   },
   {
-    asin: "B01MQD11ZG",
-    link: "https://amzn.to/4nlTv92",
-    fallbackTitle: "YouTheFan NCAA Team Spirit Coasters",
+    asin: "B07PWB3MFL",
+    link: "https://www.amazon.com/Florida-State-Seminoles-StadiumViews-Coasters/dp/B07PWB3MFL?crid=1ME34R55K7Y6V&dib=eyJ2IjoiMSJ9.J9chpuxGACXS5uDfyNzfNie1C4sGyNw4qY2rAOzIyxs1ft6Gs734e5KhpyKgYcHA6z3thJfNVQvo46wgsxvmR6Uz0WLoKUnOnNcFhfq0cKV7vUzYiem64XXqHU2tm_OpreH1esK6NMJIFuNuE0xJHS_CITlQXoYPWkR8NEwrblfMBgy6ReI9gpIXSsm9RhD8AwTskLVkrEYYE9Aj1gY8qyEKK_oHiRc36BLU1Vj5IjaFIwcvfJ77Y37JvrIsI_8yDmXJ2wmnCgl4AyMsJNNVebzuBZr7ssHVbHbsWOYwzBo.tv_GvGi1OXwSNfHatn60wUeok0KDC3Mq2WbxIF93tBc&dib_tag=se&keywords=florida%2Bstate%2Bseminoles&qid=1758548997&sprefix=florida%2Bstate%2Caps%2C139&sr=8-21-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9tdGY&th=1&linkCode=ll1&tag=cfbbelt-20&linkId=f185d6dc12e755010158d8a67bd667a6&language=en_US&ref_=as_li_ss_tl",
+    fallbackTitle: "Florida State Seminoles StadiumViews Coasters",
     fallbackImage: "/images/sport-fan-coasters.svg",
     tagline:
-      "Set out these layered team coasters to keep your tailgate surfaces spotless.",
-    cta: "Dress up the drink table →",
+      "Protect your tables with layered coasters featuring a 3D view of Doak Campbell Stadium.",
+    cta: "Lay out the FSU coasters →",
   },
   {
     asin: "B0DGFW36YX",


### PR DESCRIPTION
## Summary
- replace the garden flag entry with the Florida State Seminoles Capitol Decanter details
- swap the Zep-Pro belt item for the StadiumSpot Florida State leather belt information
- update the coasters listing to feature the StadiumViews Florida State Seminoles set

## Testing
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1551901d4833293e1316f4712651e