### PR TITLE
Center Amazon banner within full-width ad

### DIFF
--- a/components/AmazonBanner.module.css
+++ b/components/AmazonBanner.module.css
@@ -1,6 +1,9 @@
 .wrapper {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
+  margin: 1rem auto;
+  width: 100%;
+  max-width: 56.25rem;
+  padding: 0 1rem;
+  box-sizing: border-box;
 }
 
 .errorMessage {


### PR DESCRIPTION
## Summary
- center the Amazon affiliate banner inside the full-width ad container
- constrain the banner width and add padding so its cards align with the page content

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d15a6e2c1883328f472f1e378c92de