### PR TITLE
Fix Amazon banner full-width alignment

### DIFF
--- a/components/AmazonBanner.module.css
+++ b/components/AmazonBanner.module.css
@@ -1,8 +1,7 @@
 .wrapper {
-  margin: 1rem auto;
   width: 100%;
-  max-width: 56.25rem;
-  padding: 0 1rem;
+  margin: 0;
+  padding: clamp(0.75rem, 2vw, 1.5rem) clamp(1rem, 4vw, 2.5rem);
   box-sizing: border-box;
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -299,6 +299,8 @@ export default function HomePage({ data }) {
 
               <div style={{ marginTop: '1rem' }}>{getPagination()}</div>
             </div>
+          </main>
+          <div className={homeStyles.layoutAdRow}>
             <div className={`${adStyles.fullWidthAd} ${adStyles.looseBottom}`}>
               <div className={adStyles.inner}>
                 <AdSlot
@@ -308,7 +310,7 @@ export default function HomePage({ data }) {
                 />
               </div>
             </div>
-          </main>
+          </div>
           <aside className={homeStyles.sidebar}>
             <BeltBookBanner {...beltBookSpotlight} />
           </aside>

--- a/styles/HomePage.module.css
+++ b/styles/HomePage.module.css
@@ -11,7 +11,10 @@
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  align-items: stretch;
+}
+
+.layoutAdRow {
+  width: 100%;
 }
 
 .preContent {
@@ -64,9 +67,23 @@
   .layout {
     flex-direction: row;
     align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .mainContent {
+    flex: 1 1 0;
+    min-width: 0;
+    order: 1;
+  }
+
+  .layoutAdRow {
+    flex-basis: 100%;
+    order: 3;
   }
 
   .sidebar {
     width: 20rem;
+    flex: 0 0 20rem;
+    order: 2;
   }
 }


### PR DESCRIPTION
## Summary
- let the Amazon banner wrapper span the full slot width with responsive padding instead of constraining to 56rem
- refactor the home page layout so the lower ad slot lives in its own full-width row that wraps under the sidebar on large screens

## Testing
- npm run lint *(fails: ESLint must be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d15e254bcc833296a86e35cc319233