### PR TITLE
Add Impact verification meta tag to homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
+import Head from 'next/head';
 import { useRouter } from 'next/router';
 import NavBar from '../components/NavBar';
 import { teamLogoMap, normalizeTeamName, computeRecord } from '../utils/teamUtils';
@@ -53,6 +54,16 @@ export default function HomePage({ data }) {
     },
   };
 
+  const verificationMetaTag = (
+    <Head>
+      <meta
+        key="impact-site-verification"
+        name="impact-site-verification"
+        value="f17e97a8-30ec-463f-a644-9a435fadb782"
+      />
+    </Head>
+  );
+
   if (!data.length) {
     return (
       <>
@@ -63,6 +74,7 @@ export default function HomePage({ data }) {
           image="/images/fallback-helmet.png"
           structuredData={homepageStructuredData}
         />
+        {verificationMetaTag}
         <NavBar />
         <div
           style={{
@@ -155,6 +167,7 @@ export default function HomePage({ data }) {
         image="/images/fallback-helmet.png"
         structuredData={homepageStructuredData}
       />
+      {verificationMetaTag}
       <NavBar />
       <div className={homeStyles.pageContainer}>
         <div className={`${adStyles.fullWidthAd} ${adStyles.tightTop}`}>

--- a/pages/path-to-conference.js
+++ b/pages/path-to-conference.js
@@ -24,36 +24,39 @@ export default function PathToConference() {
       <div style={{ maxWidth: '900px', margin: 'auto', padding: '1rem', fontFamily: 'Arial, sans-serif', color: '#111' }}>
         <h1 style={{ fontSize: '2rem', marginBottom: '1rem', color: '#001f3f' }}>Path to the Conferences</h1>
 
-      <p style={{ fontSize: '1rem', marginBottom: '1rem' }}>
-        This page tracks the most likely way the belt could end up in each major conference during the 2025 season, based on Miami's current possession of the belt and the remaining schedule. Bowl games and playoffs are not included. Impact-Site-Verification: f17e97a8-30ec-463f-a644-9a435fadb782
-      </p>
+        <p style={{ fontSize: '1rem', marginBottom: '1rem' }}>
+          This page tracks the most likely way the belt could end up in each major conference during the 2025 season, based on
+          Miami's current possession of the belt and the remaining schedule. Bowl games and playoffs are not included.
+        </p>
 
-      <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>ACC</h2>
-      <ol>
-        <li><strong>Completed:</strong> South Florida lost to Miami (Week 3).</li>
-        <li><strong>Completed:</strong> Miami defended the belt by beating Florida 26–7 (Week 4).</li>
-        <li><strong>Next:</strong> Miami travels to Florida State on October 4 for a 7 p.m. ET kickoff.</li>
-      </ol>
+        <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>ACC</h2>
+        <ol>
+          <li><strong>Completed:</strong> South Florida lost to Miami (Week 3).</li>
+          <li><strong>Completed:</strong> Miami defended the belt by beating Florida 26–7 (Week 4).</li>
+          <li><strong>Next:</strong> Miami travels to Florida State on October 4 for a 7 p.m. ET kickoff.</li>
+        </ol>
 
-          <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>SEC</h2>
-      <p style={{ marginBottom: '0.5rem' }}>
-        Florida's quick turnaround bid fizzled in Miami. For the belt to return to the SEC, the Seminoles would need to capture it and then fall to Florida or another SEC opponent later in the fall.
-      </p>
+        <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>SEC</h2>
+        <p style={{ marginBottom: '0.5rem' }}>
+          Florida's quick turnaround bid fizzled in Miami. For the belt to return to the SEC, the Seminoles would need to capture
+          it and then fall to Florida or another SEC opponent later in the fall.
+        </p>
 
-      <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>Big 12</h2>
-      <p style={{ marginBottom: '0.5rem' }}>
-        There is no direct or likely non-bowl path to the Big 12 this season due to lack of scheduled matchups with Big 12 teams.
-      </p>
+        <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>Big 12</h2>
+        <p style={{ marginBottom: '0.5rem' }}>
+          There is no direct or likely non-bowl path to the Big 12 this season due to lack of scheduled matchups with Big 12
+          teams.
+        </p>
 
-      <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>Big Ten</h2>
-      <p style={{ marginBottom: '0.5rem' }}>
-        Similarly, no clear route exists for the belt to reach the Big Ten before the postseason.
-      </p>
+        <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>Big Ten</h2>
+        <p style={{ marginBottom: '0.5rem' }}>
+          Similarly, no clear route exists for the belt to reach the Big Ten before the postseason.
+        </p>
 
-      <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>Group of Five / Independents</h2>
-      <p style={{ marginBottom: '0.5rem' }}>
-        The belt now resides in the ACC.
-      </p>
+        <h2 style={{ fontSize: '1.5rem', marginTop: '2rem', color: '#001f3f' }}>Group of Five / Independents</h2>
+        <p style={{ marginBottom: '0.5rem' }}>
+          The belt now resides in the ACC.
+        </p>
 
         <div style={{ marginTop: '2rem', fontStyle: 'italic', color: '#444' }}>
           Belt movement is based on real schedules and historical team strength. This page will update as the season progresses.


### PR DESCRIPTION
## Summary
- add the Impact verification meta tag to the homepage head alongside the existing SEO data
- remove the verification token from the Path to the Conferences page copy so the text reads normally again

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1a7137c688332914ba2a827b5e869