### PR TITLE
Disable global Auto Ads by default (require per-page opt-in)

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -35,6 +35,7 @@ function isBlocked(pathname) {
 function AppShell({ Component, pageProps }) {
   const router = useRouter();
   const { hasContent = true } = pageProps;
+  const { enableAutoAds = false } = pageProps;
   const { autoAdsEnabled } = useAdPreferences();
 
   useEffect(() => {
@@ -44,7 +45,11 @@ function AppShell({ Component, pageProps }) {
       const contentPresent =
         typeof hasContent === "boolean" ? hasContent : bodyText.length > 0;
       const routeBlocked = isBlocked(url);
-      const shouldLoadForAutoAds = autoAdsEnabled && !routeBlocked && contentPresent;
+      const shouldLoadForAutoAds =
+        autoAdsEnabled &&
+        enableAutoAds &&
+        !routeBlocked &&
+        contentPresent;
 
       if (shouldLoadForAutoAds) {
         ensureAdsenseLoaded(PUB_ID);
@@ -56,7 +61,7 @@ function AppShell({ Component, pageProps }) {
     // on client route changes
     router.events.on("routeChangeStart", handle);
     return () => router.events.off("routeChangeStart", handle);
-  }, [router.pathname, hasContent, autoAdsEnabled]);
+  }, [router.pathname, hasContent, autoAdsEnabled, enableAutoAds]);
 
   return (
     <>


### PR DESCRIPTION
### Motivation
- Reduce unwanted ad density by preventing Auto Ads from initializing site-wide unless a page explicitly opts in.

### Description
- Add a per-page opt-in flag `pageProps.enableAutoAds` which defaults to `false` and must be true for Auto Ads to initialize.
- Include the new `enableAutoAds` flag in the Auto Ads bootstrap condition and the hook dependency list to ensure correct runtime behavior.

### Testing
- Ran `npm run lint` which failed in this environment due to missing dev dependency (`ESLint must be installed: npm install --save-dev eslint`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a87f3714f0833295d40a8228a1ca2f)