### PR TITLE
Disable AdSense page-level auto insertions between sections

### DIFF
--- a/utils/adsenseLoader.js
+++ b/utils/adsenseLoader.js
@@ -14,6 +14,14 @@ export function ensureAdsenseLoaded(pubId) {
     "script[data-cfb-belt-adsense='auto']"
   );
 
+  // Keep account-level Auto Ads from injecting additional ad blocks
+  // between content sections. We only want explicitly rendered slots.
+  window.adsbygoogle = window.adsbygoogle || [];
+  window.adsbygoogle.push({
+    google_ad_client: pubId,
+    enable_page_level_ads: false,
+  });
+
   if (existing || window.__adsenseScriptLoading) {
     if (window.__adsenseLoaded) {
       window.dispatchEvent(new Event("adsense-loaded"));
@@ -44,4 +52,3 @@ export function ensureAdsenseLoaded(pubId) {
 
   document.head.appendChild(script);
 }
-


### PR DESCRIPTION
### Motivation
- Users reported AdSense injecting additional ad blocks between nearly every content section, so the loader should prevent account-level Auto Ads while still allowing explicitly placed ad slots to render.

### Description
- Modified `utils/adsenseLoader.js` inside `ensureAdsenseLoaded` to push `{ google_ad_client: pubId, enable_page_level_ads: false }` to `window.adsbygoogle`, preventing page-level Auto Ads while preserving the existing dynamic script insertion and `adsense-loaded` / `adsense-error` event flow.

### Testing
- Ran `npm run lint`, which failed in this environment because `eslint` is not installed (no other automated tests were available or executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e8a7f43483328a8583fbeb469855)