### PR TITLE
Stop initializing AdSense page-level (auto) ads in the loader

### DIFF
--- a/utils/adsenseLoader.js
+++ b/utils/adsenseLoader.js
@@ -14,14 +14,6 @@ export function ensureAdsenseLoaded(pubId) {
     "script[data-cfb-belt-adsense='auto']"
   );
 
-  // Keep account-level Auto Ads from injecting additional ad blocks
-  // between content sections. We only want explicitly rendered slots.
-  window.adsbygoogle = window.adsbygoogle || [];
-  window.adsbygoogle.push({
-    google_ad_client: pubId,
-    enable_page_level_ads: false,
-  });
-
   if (existing || window.__adsenseScriptLoading) {
     if (window.__adsenseLoaded) {
       window.dispatchEvent(new Event("adsense-loaded"));


### PR DESCRIPTION
### Motivation
- Prevent account-level Auto Ads from being (re)enabled during script initialization so ad blocks are not injected between content sections.

### Description
- Removed the `window.adsbygoogle.push({ google_ad_client: pubId, enable_page_level_ads: false })` call from `utils/adsenseLoader.js` so `ensureAdsenseLoaded` only ensures the script is present and dispatches `adsense-loaded`/`adsense-error` events.

### Testing
- Ran `npm run -s lint` which failed in this environment because `eslint` is not installed (linting could not be completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af318950f083328bacaef0038b400f)