### PR TITLE
Load AdSense library only and defer ad initialization to ad components

### DIFF
--- a/utils/adsenseLoader.js
+++ b/utils/adsenseLoader.js
@@ -14,13 +14,8 @@ export function ensureAdsenseLoaded(pubId) {
     "script[data-cfb-belt-adsense='auto']"
   );
 
-  // Keep account-level Auto Ads from injecting additional ad blocks
-  // between content sections. We only want explicitly rendered slots.
-  window.adsbygoogle = window.adsbygoogle || [];
-  window.adsbygoogle.push({
-    google_ad_client: pubId,
-    enable_page_level_ads: false,
-  });
+  // Load only the AdSense library. Individual ad units are initialized
+  // by <AdUnit /> with `adsbygoogle.push({})` once mounted.
 
   if (existing || window.__adsenseScriptLoading) {
     if (window.__adsenseLoaded) {


### PR DESCRIPTION
### Motivation
- Prevent implicit/global ad initialization that could inject account-level or page-level ad blocks by loading only the AdSense library and letting explicit ad components initialize units.

### Description
- Remove the global `window.adsbygoogle` initialization and `push` call that previously set `google_ad_client` and `enable_page_level_ads`, and update the comment to state that individual `<AdUnit />` components will call `adsbygoogle.push({})` once mounted.

### Testing
- Ran unit tests with `yarn test` and executed a production build with `yarn build`, both completed successfully in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af32ddbd8c8332aeb7441b90f8e534)